### PR TITLE
[Feat] 사용자 매장 이용내역 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### QueryDSL generated Q classes
+/src/main/generated/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/src/main/java/com/ureca/uble/domain/usageHistory/controller/UsageHistoryController.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/controller/UsageHistoryController.java
@@ -1,0 +1,43 @@
+package com.ureca.uble.domain.usageHistory.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ureca.uble.domain.auth.dto.response.ReissueRes;
+import com.ureca.uble.domain.auth.exception.AuthErrorCode;
+import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
+import com.ureca.uble.domain.usageHistory.service.UsageHistoryService;
+import com.ureca.uble.global.dto.response.CursorPageRes;
+import com.ureca.uble.global.exception.GlobalException;
+import com.ureca.uble.global.response.CommonResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/users")
+@RequiredArgsConstructor
+public class UsageHistoryController {
+	private final UsageHistoryService usageHistoryService;
+
+	@GetMapping("/history")
+	@Operation(summary = "제휴처 이용내역 조회", description = "커서 기반으로 제휴처 이용내역을 조회합니다.")
+	public CommonResponse<CursorPageRes<UsageHistoryRes>> getUsageHistory(
+		@Parameter(hidden=true)
+		@AuthenticationPrincipal Long userId,
+		@Parameter(description = "마지막 커서 ID", required = false)
+		@RequestParam(required=false) Long lastHistoryId,
+		@Parameter(description = "페이지 크기", example = "10")
+		@RequestParam(defaultValue="10") int size
+
+	){
+		return CommonResponse.success(usageHistoryService.getUsageHistory(userId, lastHistoryId, size));
+	}
+}

--- a/src/main/java/com/ureca/uble/domain/usageHistory/controller/UsageHistoryController.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/controller/UsageHistoryController.java
@@ -1,24 +1,18 @@
 package com.ureca.uble.domain.usageHistory.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.ureca.uble.domain.auth.dto.response.ReissueRes;
-import com.ureca.uble.domain.auth.exception.AuthErrorCode;
 import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
 import com.ureca.uble.domain.usageHistory.service.UsageHistoryService;
 import com.ureca.uble.global.dto.response.CursorPageRes;
-import com.ureca.uble.global.exception.GlobalException;
 import com.ureca.uble.global.response.CommonResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController

--- a/src/main/java/com/ureca/uble/domain/usageHistory/dto/response/UsageHistoryRes.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/dto/response/UsageHistoryRes.java
@@ -1,0 +1,30 @@
+package com.ureca.uble.domain.usageHistory.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description="매장 이용내역 응답")
+public class UsageHistoryRes {
+
+	@Schema(description = "이용내역 ID", example = "100")
+	private Long id;
+
+	@Schema(description = "매장 이름", example = "투썸플레이스 선릉점")
+	private String storeName;
+
+	@Schema(description = "이용 시각", example = "2025-07-06T12:34:56")
+	private LocalDateTime usedAt;
+
+	public static UsageHistoryRes of(Long id, String storeName, LocalDateTime usedAt) {
+		return UsageHistoryRes.builder()
+			.id(id)
+			.storeName(storeName)
+			.usedAt(usedAt)
+			.build();
+	}
+}

--- a/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepository.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.ureca.uble.domain.usageHistory.repository;
+
+import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
+import com.ureca.uble.global.dto.response.CursorPageRes;
+
+public interface CustomUsageHistoryRepository {
+	CursorPageRes<UsageHistoryRes> findUsagesByUserId(Long userId, Long lastHistoryId, int size);
+}

--- a/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.ureca.uble.domain.usageHistory.repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
+import com.ureca.uble.entity.QStore;
+import com.ureca.uble.entity.QUsageHistory;
+import com.ureca.uble.global.dto.response.CursorPageRes;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomUsageHistoryRepositoryImpl implements CustomUsageHistoryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public CursorPageRes<UsageHistoryRes> findUsagesByUserId(Long userId, Long lastHistoryId, int size) {
+		QUsageHistory usage = QUsageHistory.usageHistory;
+		QStore store = QStore.store;
+
+		List<UsageHistoryRes> results = queryFactory
+			.selectFrom(usage)
+			.join(usage.store, store).fetchJoin()
+			.where(
+				usage.user.id.eq(userId),
+				lastHistoryId != null ? usage.id.lt(lastHistoryId) : null)
+			.orderBy(usage.id.desc())
+			.limit(size + 1)
+			.fetch()
+			.stream()
+			.map(u -> UsageHistoryRes.of(
+				u.getId(),
+				u.getStore().getName(),
+				u.getCreatedAt()
+			))
+			.collect(Collectors.toList());
+
+		boolean hasNext = results.size() > size;
+		Long nextCursor = hasNext ? results.get(size - 1).getId() : null;
+
+		if(hasNext){
+			results = results.subList(0, size);
+		}
+
+		return CursorPageRes.<UsageHistoryRes>builder()
+			.content(results)
+			.hasNext(hasNext)
+			.lastCursorId(nextCursor)
+			.build();
+	}
+}

--- a/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
 import com.ureca.uble.entity.QStore;
@@ -29,7 +30,8 @@ public class CustomUsageHistoryRepositoryImpl implements CustomUsageHistoryRepos
 			.join(usage.store, store).fetchJoin()
 			.where(
 				usage.user.id.eq(userId),
-				lastHistoryId != null ? usage.id.lt(lastHistoryId) : null)
+				ltHistoryId(lastHistoryId, usage)
+			)
 			.orderBy(usage.id.desc())
 			.limit(size + 1)
 			.fetch()
@@ -53,5 +55,9 @@ public class CustomUsageHistoryRepositoryImpl implements CustomUsageHistoryRepos
 			.hasNext(hasNext)
 			.lastCursorId(nextCursor)
 			.build();
+	}
+
+	private BooleanExpression ltHistoryId(Long lastHistoryId, QUsageHistory usage) {
+		return lastHistoryId != null ? usage.id.lt(lastHistoryId) : null;
 	}
 }

--- a/src/main/java/com/ureca/uble/domain/usageHistory/repository/UsageHistoryRepository.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/repository/UsageHistoryRepository.java
@@ -1,0 +1,9 @@
+package com.ureca.uble.domain.usageHistory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ureca.uble.entity.UsageHistory;
+
+public interface UsageHistoryRepository extends JpaRepository<UsageHistory, Long>, CustomUsageHistoryRepository{
+
+}

--- a/src/main/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryService.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryService.java
@@ -3,8 +3,7 @@ package com.ureca.uble.domain.usageHistory.service;
 import org.springframework.stereotype.Service;
 
 import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
-import com.ureca.uble.domain.usageHistory.repository.CustomUsageHistoryRepository;
-import com.ureca.uble.entity.UsageHistory;
+import com.ureca.uble.domain.usageHistory.repository.UsageHistoryRepository;
 import com.ureca.uble.global.dto.response.CursorPageRes;
 
 import lombok.RequiredArgsConstructor;
@@ -13,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UsageHistoryService {
 
-	private final CustomUsageHistoryRepository usageRepository;
+	private final UsageHistoryRepository usageRepository;
 
 	public CursorPageRes<UsageHistoryRes> getUsageHistory(Long userId, Long lastHistoryId, int size) {
 		return usageRepository.findUsagesByUserId(userId, lastHistoryId, size);

--- a/src/main/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryService.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryService.java
@@ -1,0 +1,21 @@
+package com.ureca.uble.domain.usageHistory.service;
+
+import org.springframework.stereotype.Service;
+
+import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
+import com.ureca.uble.domain.usageHistory.repository.CustomUsageHistoryRepository;
+import com.ureca.uble.entity.UsageHistory;
+import com.ureca.uble.global.dto.response.CursorPageRes;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UsageHistoryService {
+
+	private final CustomUsageHistoryRepository usageRepository;
+
+	public CursorPageRes<UsageHistoryRes> getUsageHistory(Long userId, Long lastHistoryId, int size) {
+		return usageRepository.findUsagesByUserId(userId, lastHistoryId, size);
+	}
+}

--- a/src/main/java/com/ureca/uble/entity/User.java
+++ b/src/main/java/com/ureca/uble/entity/User.java
@@ -43,7 +43,6 @@ public class User extends BaseEntity {
     private LocalDate birthDate;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private Gender gender;
 
     @Builder(access = PRIVATE)
@@ -65,6 +64,10 @@ public class User extends BaseEntity {
             .nickname(nickname)
             .rank(Rank.NORMAL)
             .role(Role.TMP_USER)
+            .isDeleted(false)
+            .isVipAvailable(false)
+            .birthDate(null)
+            .gender(null)
             .build();
     }
 }

--- a/src/main/java/com/ureca/uble/global/dto/response/CursorPageRes.java
+++ b/src/main/java/com/ureca/uble/global/dto/response/CursorPageRes.java
@@ -1,0 +1,21 @@
+package com.ureca.uble.global.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "커서 기반 페이지네이션 응답")
+public class CursorPageRes<T> {
+	@Schema(description = "데이터 리스트")
+	private List<T> content;
+
+	@Schema(description = "다음 페이지 존재 여부", example = "true")
+	private boolean hasNext;
+
+	@Schema(description = "마지막 커서 ID", example = "99")
+	private Long lastCursorId;
+}

--- a/src/test/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryServiceTest.java
@@ -1,0 +1,57 @@
+package com.ureca.uble.domain.usageHistory.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
+import com.ureca.uble.domain.usageHistory.repository.CustomUsageHistoryRepository;
+import com.ureca.uble.global.dto.response.CursorPageRes;
+
+@ExtendWith(MockitoExtension.class)
+public class UsageHistoryServiceTest {
+
+	@InjectMocks
+	private UsageHistoryService usageHistoryService;
+
+	@Mock
+	private CustomUsageHistoryRepository usageHistoryRepository;
+
+	@Test
+	@DisplayName("사용자 ID로 이용내역을 조회한다.")
+	void getUseageHistorySuccess(){
+		//given
+		Long userId = 1L;
+		Long lastHistoryId = null;
+		int size = 10;
+
+		List<UsageHistoryRes> content = List.of(
+			UsageHistoryRes.of(1L, "스타벅스 선릉점", LocalDateTime.now())
+		);
+		CursorPageRes<UsageHistoryRes> expectedResult = CursorPageRes.<UsageHistoryRes>builder()
+			.content(content)
+			.hasNext(false)
+			.lastCursorId(null)
+			.build();
+		when(usageHistoryRepository.findUsagesByUserId(userId, lastHistoryId, size)).thenReturn(expectedResult);
+
+		//when
+		CursorPageRes<UsageHistoryRes> result = usageHistoryService.getUsageHistory(userId, lastHistoryId, size);
+
+		//then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.isHasNext()).isFalse();
+		verify(usageHistoryRepository).findUsagesByUserId(userId, lastHistoryId, size);
+	}
+
+}

--- a/src/test/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryServiceTest.java
@@ -1,6 +1,6 @@
 package com.ureca.uble.domain.usageHistory.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
@@ -14,7 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
-import com.ureca.uble.domain.usageHistory.repository.CustomUsageHistoryRepository;
+import com.ureca.uble.domain.usageHistory.repository.UsageHistoryRepository;
 import com.ureca.uble.global.dto.response.CursorPageRes;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,7 +24,7 @@ public class UsageHistoryServiceTest {
 	private UsageHistoryService usageHistoryService;
 
 	@Mock
-	private CustomUsageHistoryRepository usageHistoryRepository;
+	private UsageHistoryRepository usageHistoryRepository;
 
 	@Test
 	@DisplayName("사용자 ID로 이용내역을 조회한다.")

--- a/src/test/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryServiceTest.java
@@ -28,7 +28,7 @@ public class UsageHistoryServiceTest {
 
 	@Test
 	@DisplayName("사용자 ID로 이용내역을 조회한다.")
-	void getUseageHistorySuccess(){
+	void getUsageHistorySuccess(){
 		//given
 		Long userId = 1L;
 		Long lastHistoryId = null;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13 

## 📝작업 내용

> 커서 기반 페이지네이션 응답 DTO 작성
- content, lastCursorId, hasNext 필드 포함

> 사용자 매장 이용내역 조회 기능 구현
- UsageHistoryController: /api/users/history API 추가
- UsageHistoryService: 사용자 ID로 이용내역 조회
- CustomUsageHistoryRepository: 커서 기반 조회 쿼리 수행
- UsageHistoryRes: 응답 DTO 정의

> 서비스 단위 테스트 작성
- 사용자 ID 기준 커서 페이지네이션 테스트

## 📷스크린샷 (선택)

> 

## 💬리뷰 요구사항(선택)

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 제휴 서비스 이용 내역을 커서 기반 페이지네이션으로 조회할 수 있는 API가 추가되었습니다.
  * 이용 내역 응답에 매장명, 이용 일시 등의 정보가 포함됩니다.
  * 커서 기반 페이지네이션을 지원하는 공통 응답 구조가 도입되었습니다.

* **버그 수정**
  * 임시 사용자 생성 시 일부 필드가 명시적으로 초기화되도록 개선되었습니다.

* **문서화**
  * API 응답 및 파라미터에 대한 Swagger 문서가 추가되었습니다.

* **테스트**
  * 이용 내역 서비스의 동작을 검증하는 단위 테스트가 추가되었습니다.

* **기타**
  * QueryDSL에서 생성되는 파일이 Git 추적 대상에서 제외되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->