### PR TITLE
[Feat] 즐겨찾기 API 구현

### DIFF
--- a/src/main/java/com/ureca/uble/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/controller/BookmarkController.java
@@ -38,7 +38,7 @@ public class BookmarkController {
      * 즐겨찾기 삭제
      *
      * @param userId 사용자 정보
-     * @param bookmarkId 제휴처 id
+     * @param bookmarkId 즐겨찾기 id
      */
     @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기 삭제")
     @DeleteMapping("/{bookmarkId}")

--- a/src/main/java/com/ureca/uble/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/controller/BookmarkController.java
@@ -2,8 +2,10 @@ package com.ureca.uble.domain.bookmark.controller;
 
 import com.ureca.uble.domain.bookmark.dto.response.CreateBookmarkRes;
 import com.ureca.uble.domain.bookmark.dto.response.DeleteBookmarkRes;
+import com.ureca.uble.domain.bookmark.dto.response.GetBookmarkRes;
 import com.ureca.uble.domain.bookmark.service.BookmarkService;
 import com.ureca.uble.global.response.CommonResponse;
+import com.ureca.uble.global.response.CursorPageRes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -46,5 +48,24 @@ public class BookmarkController {
         @Parameter(description = "즐겨찾기 id", required = true)
         @PathVariable Long bookmarkId) {
         return CommonResponse.success(bookmarkService.deleteBookmark(userId, bookmarkId));
+    }
+
+    /**
+     * 즐겨찾기 전체 조회
+     *
+     * @param userId 사용자 정보
+     * @param lastBookmarkId 마지막 커서 id
+     * @param size 페이지 크기
+     */
+    @Operation(summary = "즐겨찾기 전체 조회", description = "즐겨찾기 전체 조회")
+    @GetMapping
+    public CommonResponse<CursorPageRes<GetBookmarkRes>> getBookmarks(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal Long userId,
+        @Parameter(description = "마지막 즐겨찾기 Id")
+        @RequestParam(required = false) Long lastBookmarkId,
+        @Parameter(description = "한 번에 가져올 크기")
+        @RequestParam(defaultValue = "5") int size) {
+        return CommonResponse.success(bookmarkService.getBookmarks(userId, lastBookmarkId, size));
     }
 }

--- a/src/main/java/com/ureca/uble/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/controller/BookmarkController.java
@@ -1,0 +1,50 @@
+package com.ureca.uble.domain.bookmark.controller;
+
+import com.ureca.uble.domain.bookmark.dto.response.CreateBookmarkRes;
+import com.ureca.uble.domain.bookmark.dto.response.DeleteBookmarkRes;
+import com.ureca.uble.domain.bookmark.service.BookmarkService;
+import com.ureca.uble.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/bookmarks")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    /**
+     * 즐겨찾기 추가
+     * @param userId 사용자 정보
+     * @param brandId 제휴처 id
+     */
+    @Operation(summary = "즐겨찾기 추가", description = "즐겨찾기 추가")
+    @PostMapping
+    public CommonResponse<CreateBookmarkRes> createBookmark(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal Long userId,
+        @Parameter(description = "제휴처 id", required = true)
+        @RequestParam Long brandId) {
+        return CommonResponse.success(bookmarkService.createBookmark(userId, brandId));
+    }
+
+    /**
+     * 즐겨찾기 삭제
+     *
+     * @param userId 사용자 정보
+     * @param bookmarkId 제휴처 id
+     */
+    @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기 삭제")
+    @DeleteMapping("/{bookmarkId}")
+    public CommonResponse<DeleteBookmarkRes> deleteBookmark(
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal Long userId,
+        @Parameter(description = "즐겨찾기 id", required = true)
+        @PathVariable Long bookmarkId) {
+        return CommonResponse.success(bookmarkService.deleteBookmark(userId, bookmarkId));
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/bookmark/dto/response/CreateBookmarkRes.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/dto/response/CreateBookmarkRes.java
@@ -1,0 +1,13 @@
+package com.ureca.uble.domain.bookmark.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "즐겨찾기 추가 반환 DTO")
+public class CreateBookmarkRes {
+    @Schema(description = "생성된 즐겨찾기 id", example = "1")
+    private Long bookmarkId;
+}

--- a/src/main/java/com/ureca/uble/domain/bookmark/dto/response/DeleteBookmarkRes.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/dto/response/DeleteBookmarkRes.java
@@ -1,0 +1,11 @@
+package com.ureca.uble.domain.bookmark.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "즐겨찾기 삭제 반환 DTO")
+public class DeleteBookmarkRes {
+}

--- a/src/main/java/com/ureca/uble/domain/bookmark/dto/response/GetBookmarkRes.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/dto/response/GetBookmarkRes.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "즐겨찾기 정보 반환 DTO")
 public class GetBookmarkRes {
     @Schema(description = "즐겨찾기 id", example = "true")
     private Long bookmarkId;

--- a/src/main/java/com/ureca/uble/domain/bookmark/dto/response/GetBookmarkRes.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/dto/response/GetBookmarkRes.java
@@ -1,0 +1,35 @@
+package com.ureca.uble.domain.bookmark.dto.response;
+
+import com.ureca.uble.entity.Bookmark;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetBookmarkRes {
+    @Schema(description = "즐겨찾기 id", example = "true")
+    private Long bookmarkId;
+
+    @Schema(description = "제휴처 id", example = "1")
+    private Long brandId;
+
+    @Schema(description = "제휴처 이름", example = "1")
+    private String brandName;
+
+    @Schema(description = "제휴처 카테고리", example = "문화/여가")
+    private String category;
+
+    @Schema(description = "제휴처 로고 이미지", example = "링크")
+    private String brandImageUrl;
+
+    public static GetBookmarkRes from(Bookmark bookmark) {
+        return GetBookmarkRes.builder()
+            .bookmarkId(bookmark.getId())
+            .brandId(bookmark.getBrand().getId())
+            .brandName(bookmark.getBrand().getName())
+            .category(bookmark.getBrand().getCategory().getName())
+            .brandImageUrl(bookmark.getBrand().getImageUrl())
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/bookmark/exception/BookmarkErrorCode.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/exception/BookmarkErrorCode.java
@@ -1,0 +1,18 @@
+package com.ureca.uble.domain.bookmark.exception;
+
+import com.ureca.uble.global.exception.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BookmarkErrorCode implements ResultCode {
+    BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, 6000, "즐겨찾기를 찾을 수 없습니다."),
+    DUPLICATED_BOOKMARK(HttpStatus.BAD_REQUEST, 6001, "이미 존재하는 즐겨찾기입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/ureca/uble/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/repository/BookmarkRepository.java
@@ -4,5 +4,5 @@ import com.ureca.uble.entity.Bookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, CustomBookmarkRepository {
-    boolean existsByBrand_IdAndUser_Id(Long brandId, Long user);
+    boolean existsByBrand_IdAndUser_Id(Long brandId, Long userId);
 }

--- a/src/main/java/com/ureca/uble/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,8 @@
+package com.ureca.uble.domain.bookmark.repository;
+
+import com.ureca.uble.entity.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, CustomBookmarkRepository {
+    boolean existsByBrand_IdAndUser_Id(Long brandId, Long user);
+}

--- a/src/main/java/com/ureca/uble/domain/bookmark/repository/CustomBookmarkRepository.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/repository/CustomBookmarkRepository.java
@@ -1,0 +1,9 @@
+package com.ureca.uble.domain.bookmark.repository;
+
+import com.ureca.uble.entity.Bookmark;
+
+import java.util.List;
+
+public interface CustomBookmarkRepository {
+    List<Bookmark> getBookmarksByPage(Long userId, int size, Long lastBookmarkId);
+}

--- a/src/main/java/com/ureca/uble/domain/bookmark/repository/CustomBookmarkRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/repository/CustomBookmarkRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.ureca.uble.domain.bookmark.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.uble.entity.Bookmark;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.ureca.uble.entity.QBookmark.bookmark;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomBookmarkRepositoryImpl implements CustomBookmarkRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Bookmark> getBookmarksByPage(Long userId, int size, Long lastBookmarkId) {
+        return jpaQueryFactory
+            .selectFrom(bookmark)
+            .where(
+                ltBookmarkId(lastBookmarkId),
+                bookmark.user.id.eq(userId)
+            )
+            .orderBy(bookmark.id.desc())
+            .limit(size)
+            .fetch();
+    }
+
+    private BooleanExpression ltBookmarkId(Long lastBookmarkId) {
+        return (lastBookmarkId == null) ? null : bookmark.id.lt(lastBookmarkId);
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/service/BookmarkService.java
@@ -1,0 +1,68 @@
+package com.ureca.uble.domain.bookmark.service;
+
+import com.ureca.uble.domain.bookmark.dto.response.CreateBookmarkRes;
+import com.ureca.uble.domain.bookmark.dto.response.DeleteBookmarkRes;
+import com.ureca.uble.domain.bookmark.repository.BookmarkRepository;
+import com.ureca.uble.entity.Bookmark;
+import com.ureca.uble.entity.Brand;
+import com.ureca.uble.entity.User;
+import com.ureca.uble.global.exception.GlobalException;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.ureca.uble.domain.auth.exception.AuthErrorCode.UNAUTHORIZED_ACCESS;
+import static com.ureca.uble.domain.bookmark.exception.BookmarkErrorCode.BOOKMARK_NOT_FOUND;
+import static com.ureca.uble.domain.bookmark.exception.BookmarkErrorCode.DUPLICATED_BOOKMARK;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final EntityManager em;
+
+    /**
+     * 즐겨찾기 생성
+     */
+    @Transactional
+    public CreateBookmarkRes createBookmark(Long userId, Long brandId) {
+        // 즐겨찾기 중복 생성 방지
+        if (bookmarkRepository.existsByBrand_IdAndUser_Id(brandId, userId)) {
+            throw new GlobalException(DUPLICATED_BOOKMARK);
+        }
+
+        // 즐겨찾기 생성
+        Brand brandRef = em.getReference(Brand.class, brandId);
+        User userRef = em.getReference(User.class, userId);
+
+        Bookmark savedBookmark = bookmarkRepository.save(Bookmark.of(userRef, brandRef));
+
+        return new CreateBookmarkRes(savedBookmark.getId());
+    }
+
+    /**
+     * 즐겨찾기 삭제
+     */
+    @Transactional
+    public DeleteBookmarkRes deleteBookmark(Long userId, Long bookmarkId) {
+        Bookmark bookmark = findBookmark(bookmarkId);
+        checkAuthority(userId, bookmark);
+
+        bookmarkRepository.delete(bookmark);
+
+        return new DeleteBookmarkRes();
+    }
+
+    private void checkAuthority(Long userId, Bookmark bookmark) {
+        if (!bookmark.getUser().getId().equals(userId)) {
+            throw new GlobalException(UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private Bookmark findBookmark(Long bookmarkId) {
+        return bookmarkRepository.findById(bookmarkId)
+            .orElseThrow(() -> new GlobalException(BOOKMARK_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/service/BookmarkService.java
@@ -2,15 +2,20 @@ package com.ureca.uble.domain.bookmark.service;
 
 import com.ureca.uble.domain.bookmark.dto.response.CreateBookmarkRes;
 import com.ureca.uble.domain.bookmark.dto.response.DeleteBookmarkRes;
+import com.ureca.uble.domain.bookmark.dto.response.GetBookmarkRes;
 import com.ureca.uble.domain.bookmark.repository.BookmarkRepository;
 import com.ureca.uble.entity.Bookmark;
 import com.ureca.uble.entity.Brand;
 import com.ureca.uble.entity.User;
 import com.ureca.uble.global.exception.GlobalException;
+import com.ureca.uble.global.response.CursorPageRes;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.ureca.uble.domain.auth.exception.AuthErrorCode.UNAUTHORIZED_ACCESS;
 import static com.ureca.uble.domain.bookmark.exception.BookmarkErrorCode.BOOKMARK_NOT_FOUND;
@@ -53,6 +58,23 @@ public class BookmarkService {
         bookmarkRepository.delete(bookmark);
 
         return new DeleteBookmarkRes();
+    }
+
+    /**
+     * 즐겨찾기 조회
+     */
+    @Transactional
+    public CursorPageRes<GetBookmarkRes> getBookmarks(Long userId, Long lastBookmarkId, int size) {
+        List<GetBookmarkRes> bookmarkList = new ArrayList<>(bookmarkRepository.getBookmarksByPage(userId, size + 1, lastBookmarkId)
+            .stream().map(GetBookmarkRes::from).toList());
+
+        // 다음 페이지 여부 확인
+        boolean hasNext = (bookmarkList.size() > size);
+        if (hasNext) bookmarkList.remove(bookmarkList.size() - 1);
+
+        long lastCursorId = bookmarkList.get(bookmarkList.size() - 1).getBookmarkId();
+
+        return CursorPageRes.of(bookmarkList, hasNext, lastCursorId);
     }
 
     private void checkAuthority(Long userId, Bookmark bookmark) {

--- a/src/main/java/com/ureca/uble/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/ureca/uble/domain/bookmark/service/BookmarkService.java
@@ -63,7 +63,7 @@ public class BookmarkService {
     /**
      * 즐겨찾기 조회
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public CursorPageRes<GetBookmarkRes> getBookmarks(Long userId, Long lastBookmarkId, int size) {
         List<GetBookmarkRes> bookmarkList = new ArrayList<>(bookmarkRepository.getBookmarksByPage(userId, size + 1, lastBookmarkId)
             .stream().map(GetBookmarkRes::from).toList());

--- a/src/main/java/com/ureca/uble/domain/usageHistory/controller/UsageHistoryController.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/controller/UsageHistoryController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
 import com.ureca.uble.domain.usageHistory.service.UsageHistoryService;
-import com.ureca.uble.global.dto.response.CursorPageRes;
+import com.ureca.uble.global.response.CursorPageRes;
 import com.ureca.uble.global.response.CommonResponse;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepository.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepository.java
@@ -1,7 +1,7 @@
 package com.ureca.uble.domain.usageHistory.repository;
 
 import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
-import com.ureca.uble.global.dto.response.CursorPageRes;
+import com.ureca.uble.global.response.CursorPageRes;
 
 public interface CustomUsageHistoryRepository {
 	CursorPageRes<UsageHistoryRes> findUsagesByUserId(Long userId, Long lastHistoryId, int size);

--- a/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepositoryImpl.java
@@ -50,11 +50,7 @@ public class CustomUsageHistoryRepositoryImpl implements CustomUsageHistoryRepos
 			results = results.subList(0, size);
 		}
 
-		return CursorPageRes.<UsageHistoryRes>builder()
-			.content(results)
-			.hasNext(hasNext)
-			.lastCursorId(nextCursor)
-			.build();
+		return CursorPageRes.of(results, hasNext, lastHistoryId);
 	}
 
 	private BooleanExpression ltHistoryId(Long lastHistoryId, QUsageHistory usage) {

--- a/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepositoryImpl.java
@@ -10,7 +10,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
 import com.ureca.uble.entity.QStore;
 import com.ureca.uble.entity.QUsageHistory;
-import com.ureca.uble.global.dto.response.CursorPageRes;
+import com.ureca.uble.global.response.CursorPageRes;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/repository/CustomUsageHistoryRepositoryImpl.java
@@ -50,7 +50,7 @@ public class CustomUsageHistoryRepositoryImpl implements CustomUsageHistoryRepos
 			results = results.subList(0, size);
 		}
 
-		return CursorPageRes.of(results, hasNext, lastHistoryId);
+		return CursorPageRes.of(results, hasNext, nextCursor);
 	}
 
 	private BooleanExpression ltHistoryId(Long lastHistoryId, QUsageHistory usage) {

--- a/src/main/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryService.java
+++ b/src/main/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
 import com.ureca.uble.domain.usageHistory.repository.UsageHistoryRepository;
-import com.ureca.uble.global.dto.response.CursorPageRes;
+import com.ureca.uble.global.response.CursorPageRes;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/ureca/uble/entity/Bookmark.java
+++ b/src/main/java/com/ureca/uble/entity/Bookmark.java
@@ -27,4 +27,11 @@ public class Bookmark extends BaseEntity {
         this.user = user;
         this.brand = brand;
     }
+
+    public static Bookmark of(User user, Brand brand) {
+        return Bookmark.builder()
+            .user(user)
+            .brand(brand)
+            .build();
+    }
 }

--- a/src/main/java/com/ureca/uble/entity/Brand.java
+++ b/src/main/java/com/ureca/uble/entity/Brand.java
@@ -16,16 +16,20 @@ import static lombok.AccessLevel.PRIVATE;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Brand extends BaseEntity {
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
     @Column(nullable = false)
     private String name;
 
-    @Column(name = "csr_number", nullable = false)
+    @Column(name = "csr_number")
     private String csrNumber;
 
-    @Column(nullable = false)
+    @Column
     private String description;
 
-    @Column(name = "image_url", nullable = false)
+    @Column(name = "image_url")
     private String imageUrl;
 
     @Enumerated(EnumType.STRING)
@@ -46,8 +50,9 @@ public class Brand extends BaseEntity {
     private RankType rankType;
 
     @Builder(access = PRIVATE)
-    private Brand(String name, String csrNumber, String description, String imageUrl, Season season,
+    private Brand(Category category, String name, String csrNumber, String description, String imageUrl, Season season,
                   Boolean isOnline, Boolean isLocal, String reservationUrl, RankType rankType) {
+        this.category = category;
         this.name = name;
         this.csrNumber = csrNumber;
         this.description = description;

--- a/src/main/java/com/ureca/uble/global/response/CursorPageRes.java
+++ b/src/main/java/com/ureca/uble/global/response/CursorPageRes.java
@@ -1,4 +1,4 @@
-package com.ureca.uble.global.dto.response;
+package com.ureca.uble.global.response;
 
 import java.util.List;
 
@@ -18,4 +18,12 @@ public class CursorPageRes<T> {
 
 	@Schema(description = "마지막 커서 ID", example = "99")
 	private Long lastCursorId;
+
+	public static <T> CursorPageRes<T> of(List<T> content, boolean hasNext, Long lastCursorId) {
+		return CursorPageRes.<T>builder()
+			.content(content)
+			.hasNext(hasNext)
+			.lastCursorId(lastCursorId)
+			.build();
+	}
 }

--- a/src/test/java/com/ureca/uble/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/bookmark/service/BookmarkServiceTest.java
@@ -2,21 +2,27 @@ package com.ureca.uble.domain.bookmark.service;
 
 import com.ureca.uble.domain.bookmark.dto.response.CreateBookmarkRes;
 import com.ureca.uble.domain.bookmark.dto.response.DeleteBookmarkRes;
+import com.ureca.uble.domain.bookmark.dto.response.GetBookmarkRes;
 import com.ureca.uble.domain.bookmark.repository.BookmarkRepository;
 import com.ureca.uble.entity.Bookmark;
 import com.ureca.uble.entity.Brand;
+import com.ureca.uble.entity.Category;
 import com.ureca.uble.entity.User;
+import com.ureca.uble.global.exception.GlobalException;
+import com.ureca.uble.global.response.CursorPageRes;
 import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -36,6 +42,7 @@ class BookmarkServiceTest {
      * 즐겨찾기 생성 Test
      */
     @Test
+    @DisplayName("즐겨찾기를 새롭게 생성한다.")
     void createBookmark_create_check() {
         // given
         Long userId = 1L;
@@ -66,10 +73,29 @@ class BookmarkServiceTest {
         verify(bookmarkRepository).save(any(Bookmark.class));
     }
 
+    @Test
+    @DisplayName("이미 존재하는 즐겨찾기를 추가할 경우 에러가 발생한다.")
+    void createBookmark_duplicate_check() {
+        // given
+        Long userId = 1L;
+        Long brandId = 2L;
+
+        when(bookmarkRepository.existsByBrand_IdAndUser_Id(brandId, userId)).thenReturn(true);
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, () -> {
+            bookmarkService.createBookmark(userId, brandId);
+        });
+
+        // then
+        assertEquals(6001, exception.getResultCode().getCode());
+    }
+
     /**
      * 즐겨찾기 삭제 Test
      */
     @Test
+    @DisplayName("존재하는 즐겨찾기를 삭제한다.")
     void deleteBookmark_delete_check() {
         // given
         Long userId = 1L;
@@ -90,5 +116,43 @@ class BookmarkServiceTest {
         assertNotNull(res);
         verify(bookmarkRepository).findById(bookmarkId);
         verify(bookmarkRepository).delete(mockBookmark);
+    }
+
+    /**
+     * 즐겨찾기 전체 조회 Test
+     */
+    @Test
+    @DisplayName("페이지네이션을 통해 즐겨찾기 목록을 조회한다.")
+    void getBookmarks_get_first_check() {
+        //given
+        Long userId = 1L;
+        Long lastBookmarkId = null;
+        int size = 5;
+
+        Brand mockBrand = mock(Brand.class);
+        when(mockBrand.getId()).thenReturn(1L);
+
+        Category mockCategory = mock(Category.class);
+        when(mockCategory.getName()).thenReturn("tmpCategory");
+
+        Bookmark mockBookmark1 = mock(Bookmark.class);
+        Bookmark mockBookmark2 = mock(Bookmark.class);
+
+        when(mockBookmark1.getBrand()).thenReturn(mockBrand);
+        when(mockBookmark2.getBrand()).thenReturn(mockBrand);
+        when(mockBookmark1.getBrand().getCategory()).thenReturn(mockCategory);
+        when(mockBookmark2.getBrand().getCategory()).thenReturn(mockCategory);
+
+        List<Bookmark> content = List.of(mockBookmark1, mockBookmark2);
+        when(bookmarkRepository.getBookmarksByPage(userId, size + 1, lastBookmarkId)).thenReturn(content);
+
+        //when
+        CursorPageRes<GetBookmarkRes> result = bookmarkService.getBookmarks(userId, lastBookmarkId, size);
+
+        //then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.isHasNext()).isFalse();
+        verify(bookmarkRepository).getBookmarksByPage(userId, size + 1, lastBookmarkId);
     }
 }

--- a/src/test/java/com/ureca/uble/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/bookmark/service/BookmarkServiceTest.java
@@ -1,0 +1,94 @@
+package com.ureca.uble.domain.bookmark.service;
+
+import com.ureca.uble.domain.bookmark.dto.response.CreateBookmarkRes;
+import com.ureca.uble.domain.bookmark.dto.response.DeleteBookmarkRes;
+import com.ureca.uble.domain.bookmark.repository.BookmarkRepository;
+import com.ureca.uble.entity.Bookmark;
+import com.ureca.uble.entity.Brand;
+import com.ureca.uble.entity.User;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BookmarkServiceTest {
+
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+
+    @Mock
+    private EntityManager em;
+
+    @InjectMocks
+    private BookmarkService bookmarkService;
+
+    /**
+     * 즐겨찾기 생성 Test
+     */
+    @Test
+    void createBookmark_create_check() {
+        // given
+        Long userId = 1L;
+        Long brandId = 2L;
+        Long bookmarkId = 3L;
+
+        User mockUser = mock(User.class);
+        Brand mockBrand = mock(Brand.class);
+
+        Bookmark savedBookmark = mock(Bookmark.class);
+        when(savedBookmark.getId()).thenReturn(bookmarkId);
+
+        when(bookmarkRepository.existsByBrand_IdAndUser_Id(brandId, userId)).thenReturn(false);
+        when(em.getReference(User.class, userId)).thenReturn(mockUser);
+        when(em.getReference(Brand.class, brandId)).thenReturn(mockBrand);
+        when(bookmarkRepository.save(any(Bookmark.class))).thenReturn(savedBookmark);
+
+        // when
+        CreateBookmarkRes res = bookmarkService.createBookmark(userId, brandId);
+
+        // then
+        assertNotNull(res);
+        assertEquals(bookmarkId, res.getBookmarkId());
+
+        verify(bookmarkRepository).existsByBrand_IdAndUser_Id(brandId, userId);
+        verify(em).getReference(User.class, userId);
+        verify(em).getReference(Brand.class, brandId);
+        verify(bookmarkRepository).save(any(Bookmark.class));
+    }
+
+    /**
+     * 즐겨찾기 삭제 Test
+     */
+    @Test
+    void deleteBookmark_delete_check() {
+        // given
+        Long userId = 1L;
+        Long bookmarkId = 10L;
+
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn(userId);
+
+        Bookmark mockBookmark = mock(Bookmark.class);
+        when(mockBookmark.getUser()).thenReturn(mockUser);
+
+        when(bookmarkRepository.findById(bookmarkId)).thenReturn(Optional.of(mockBookmark));
+
+        // when
+        DeleteBookmarkRes res = bookmarkService.deleteBookmark(userId, bookmarkId);
+
+        // then
+        assertNotNull(res);
+        verify(bookmarkRepository).findById(bookmarkId);
+        verify(bookmarkRepository).delete(mockBookmark);
+    }
+}

--- a/src/test/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryServiceTest.java
@@ -15,7 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.ureca.uble.domain.usageHistory.dto.response.UsageHistoryRes;
 import com.ureca.uble.domain.usageHistory.repository.UsageHistoryRepository;
-import com.ureca.uble.global.dto.response.CursorPageRes;
+import com.ureca.uble.global.response.CursorPageRes;
 
 @ExtendWith(MockitoExtension.class)
 public class UsageHistoryServiceTest {

--- a/src/test/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/usageHistory/service/UsageHistoryServiceTest.java
@@ -37,11 +37,7 @@ public class UsageHistoryServiceTest {
 		List<UsageHistoryRes> content = List.of(
 			UsageHistoryRes.of(1L, "스타벅스 선릉점", LocalDateTime.now())
 		);
-		CursorPageRes<UsageHistoryRes> expectedResult = CursorPageRes.<UsageHistoryRes>builder()
-			.content(content)
-			.hasNext(false)
-			.lastCursorId(null)
-			.build();
+		CursorPageRes<UsageHistoryRes> expectedResult = CursorPageRes.of(content, false, null);
 		when(usageHistoryRepository.findUsagesByUserId(userId, lastHistoryId, size)).thenReturn(expectedResult);
 
 		//when


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11 

## 📝작업 내용

> 즐겨찾기 추가
- 즐겨찾기를 추가합니다. 중복 즐겨찾기가 존재하는 경우 6001 에러를 반환합니다.

> 즐겨찾기 제거
- 즐겨찾기가 사용자 본인의 것인지 검증한 후 즐겨찾기를 제거합니다.

> 즐겨찾기 목록 조회
- 즐겨찾기 목록을 최근 추가 순(id.desc)으로 반환합니다.
- no offset 기반 페이지네이션을 적용하였습니다.

> Test Code
- 각 기능에 대한 테스트 코드를 작성하였습니다.

> CursorPageRes - Builder 추가
- of 정적 메소드를 생성하고, UsageHistory의 페이지네이션에 적용하도록 수정하였습니다.

## 📷스크린샷 (선택)


## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 즐겨찾기(북마크) 추가, 삭제, 조회 기능이 제공됩니다. (마이페이지 등에서 즐겨찾기 브랜드 목록 확인 가능)
  * 즐겨찾기 목록은 커서 기반 페이지네이션을 지원합니다.

* **버그 수정/개선**
  * 일부 응답 객체(CursorPageRes) 생성 방식이 간소화되어 일관성이 향상되었습니다.

* **테스트**
  * 즐겨찾기 서비스의 주요 동작(추가, 중복 방지, 삭제, 조회)에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->