### PR TITLE
[Feat] 혜택 사용 가능 여부 초기화 스케줄러 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
     // postGIS
     implementation 'org.hibernate.orm:hibernate-spatial:6.4.0.Final'
     implementation 'org.locationtech.jts:jts-core:1.19.0'
+
+    // spring batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,12 @@ dependencies {
 
     // spring batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+    // Redisson
+    implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
+
+    // elasticache (Redis)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,14 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  redis:
+    image: redis:latest
+    command: ["redis-server", "--requirepass", "ublepwd"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
 volumes:
   postgres_data:
+  redis_data:

--- a/src/main/java/com/ureca/uble/UbleApplication.java
+++ b/src/main/java/com/ureca/uble/UbleApplication.java
@@ -2,8 +2,10 @@ package com.ureca.uble;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class UbleApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/ureca/uble/domain/brand/repository/BenefitRepository.java
+++ b/src/main/java/com/ureca/uble/domain/brand/repository/BenefitRepository.java
@@ -1,12 +1,14 @@
 package com.ureca.uble.domain.brand.repository;
 
-import java.util.Optional;
-
+import com.ureca.uble.entity.Benefit;
+import com.ureca.uble.entity.enums.Period;
+import com.ureca.uble.entity.enums.Rank;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.ureca.uble.entity.Benefit;
+import java.util.List;
+import java.util.Optional;
 
 public interface BenefitRepository extends JpaRepository<Benefit, Long> {
     @Query(value = """
@@ -21,4 +23,6 @@ public interface BenefitRepository extends JpaRepository<Benefit, Long> {
         LIMIT 1
     """, nativeQuery = true)
     Optional<Benefit> findNormalBenefitByStoreId(@Param("storeId") Long storeId);
+
+    List<Benefit> findAllByPeriodAndRank(Period period, Rank rank);
 }

--- a/src/main/java/com/ureca/uble/domain/store/controller/StoreController.java
+++ b/src/main/java/com/ureca/uble/domain/store/controller/StoreController.java
@@ -26,6 +26,7 @@ public class StoreController {
      * @param longitude 경도
      * @param distance 거리
      * @param categoryId 카테고리 id
+     * @param brandId 제휴처 id
      * @param season 계절 정보
      * @param isLocal 우리 동네 여부
      */

--- a/src/main/java/com/ureca/uble/domain/users/repository/UsageCountRepository.java
+++ b/src/main/java/com/ureca/uble/domain/users/repository/UsageCountRepository.java
@@ -4,10 +4,19 @@ import com.ureca.uble.entity.Benefit;
 import com.ureca.uble.entity.UsageCount;
 import com.ureca.uble.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 public interface UsageCountRepository extends JpaRepository<UsageCount, Long> {
     Optional<UsageCount> findByUserAndBenefit(User user, Benefit benefit);
     void deleteByUser(User user);
+
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE usage_count SET count = 0, isavailable = true WHERE benefit_id = :id", nativeQuery = true)
+    int resetCountAndIsAvailableByBenefitId(@Param("id") Long id);
 }

--- a/src/main/java/com/ureca/uble/domain/users/repository/UsageCountRepository.java
+++ b/src/main/java/com/ureca/uble/domain/users/repository/UsageCountRepository.java
@@ -4,9 +4,18 @@ import com.ureca.uble.entity.Benefit;
 import com.ureca.uble.entity.UsageCount;
 import com.ureca.uble.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 public interface UsageCountRepository extends JpaRepository<UsageCount, Long> {
     Optional<UsageCount> findByUserAndBenefit(User user, Benefit benefit);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE UsageCount u SET u.count = 0, u.isAvailable = true WHERE u.benefit.id = :benefitId")
+    int resetCntByBenefitId(@Param("benefitId") Long benefitId);
 }

--- a/src/main/java/com/ureca/uble/global/config/BatchConfig.java
+++ b/src/main/java/com/ureca/uble/global/config/BatchConfig.java
@@ -1,0 +1,23 @@
+package com.ureca.uble.global.config;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableBatchProcessing
+public class BatchConfig {
+
+    @Bean(name = "batchTaskExecutor")
+    public TaskExecutor batchTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("Batch-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/ureca/uble/global/config/RedisConfig.java
+++ b/src/main/java/com/ureca/uble/global/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package com.ureca.uble.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${redis.ssl-enable}")
+    private boolean sslEnable;
+
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+            .setAddress("rediss://" + host + ":" + port)
+            .setSslEnableEndpointIdentification(sslEnable);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/ureca/uble/global/schedule/UsageScheduler.java
+++ b/src/main/java/com/ureca/uble/global/schedule/UsageScheduler.java
@@ -1,0 +1,60 @@
+package com.ureca.uble.global.schedule;
+
+import com.ureca.uble.entity.enums.Period;
+import com.ureca.uble.global.schedule.batch.UsageBatchRunner;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UsageScheduler {
+
+    private final UsageBatchRunner batchRunner;
+
+    // 하루에 한 번 (매일 자정)
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateDaily() {
+        log.info("[NORMAL] DAILY 초기화 작업 시작: {}", LocalDateTime.now());
+        batchRunner.runNormalBatchAsync(Period.DAILY);
+    }
+
+    // 일주에 한 번 (매주 월요일 자정)
+    @Scheduled(cron = "0 0 0 * * 1")
+    public void updateWeekly() {
+        log.info("[NORMAL] WEEKLY 초기화 작업 시작: {}", LocalDateTime.now());
+        batchRunner.runNormalBatchAsync(Period.WEEKLY);
+    }
+
+    // 한달에 한 번 (매월 1일 자정)
+    @Scheduled(cron = "0 0 0 1 * *")
+    public void updateMonthly() {
+        log.info("[NORMAL] MONTHLY 초기화 작업 시작: {}", LocalDateTime.now());
+        batchRunner.runNormalBatchAsync(Period.MONTHLY);
+    }
+
+    // 일년에 한 번 (매년 1월 1일 자정)
+    @Scheduled(cron = "0 0 0 1 1 *")
+    public void updateYearly() {
+        log.info("[NORMAL] YEARLY 초기화 작업 시작: {}", LocalDateTime.now());
+        batchRunner.runNormalBatchAsync(Period.YEARLY);
+    }
+
+    // 한달에 한 번 (매월 1일 자정)
+    @Scheduled(cron = "0 0 0 1 * *")
+    public void updateVip() {
+        log.info("[VIP] MONTHLY 초기화 작업 시작: {}", LocalDateTime.now());
+        batchRunner.runVipBatchAsync();
+    }
+
+    // 하루에 한 번 (매일 자정)
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateLocal() {
+        log.info("[LOCAL] DAILY 초기화 작업 시작: {}", LocalDateTime.now());
+        batchRunner.runLocalBatchAsync();
+    }
+}

--- a/src/main/java/com/ureca/uble/global/schedule/UsageScheduler.java
+++ b/src/main/java/com/ureca/uble/global/schedule/UsageScheduler.java
@@ -2,6 +2,7 @@ package com.ureca.uble.global.schedule;
 
 import com.ureca.uble.entity.enums.Period;
 import com.ureca.uble.global.schedule.batch.UsageBatchRunner;
+import com.ureca.uble.global.schedule.util.RedisLockUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -15,46 +16,71 @@ import java.time.LocalDateTime;
 public class UsageScheduler {
 
     private final UsageBatchRunner batchRunner;
+    private final RedisLockUtil redisLockUtil;
 
     // 하루에 한 번 (매일 자정)
-    @Scheduled(cron = "0 0 0 * * *")
+//    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 1,11,21,31,41,51 * * * *")
     public void updateDaily() {
-        log.info("[NORMAL] DAILY 초기화 작업 시작: {}", LocalDateTime.now());
-        batchRunner.runNormalBatchAsync(Period.DAILY);
+        redisLockUtil.executeWithLockWithRetry("normal-daily-lock", 1, 300, () -> {
+            log.info("[NORMAL] DAILY 초기화 작업 시작: {}", LocalDateTime.now());
+            batchRunner.runNormalBatch(Period.DAILY);
+            return null;
+        });
     }
 
     // 일주에 한 번 (매주 월요일 자정)
-    @Scheduled(cron = "0 0 0 * * 1")
+//    @Scheduled(cron = "0 0 0 * * 1")
+    @Scheduled(cron = "0 2,12,22,32,42,52 * * * *")
     public void updateWeekly() {
-        log.info("[NORMAL] WEEKLY 초기화 작업 시작: {}", LocalDateTime.now());
-        batchRunner.runNormalBatchAsync(Period.WEEKLY);
+        redisLockUtil.executeWithLockWithRetry("normal-weekly-lock", 1, 300, () -> {
+            log.info("[NORMAL] WEEKLY 초기화 작업 시작: {}", LocalDateTime.now());
+            batchRunner.runNormalBatch(Period.WEEKLY);
+            return null;
+        });
     }
 
     // 한달에 한 번 (매월 1일 자정)
-    @Scheduled(cron = "0 0 0 1 * *")
+//    @Scheduled(cron = "0 0 0 1 * *")
+    @Scheduled(cron = "0 3,13,23,33,43,53 * * * *")
     public void updateMonthly() {
-        log.info("[NORMAL] MONTHLY 초기화 작업 시작: {}", LocalDateTime.now());
-        batchRunner.runNormalBatchAsync(Period.MONTHLY);
+        redisLockUtil.executeWithLockWithRetry("normal-monthly-lock", 1, 300, () -> {
+            log.info("[NORMAL] MONTHLY 초기화 작업 시작: {}", LocalDateTime.now());
+            batchRunner.runNormalBatch(Period.MONTHLY);
+            return null;
+        });
     }
 
     // 일년에 한 번 (매년 1월 1일 자정)
-    @Scheduled(cron = "0 0 0 1 1 *")
+//    @Scheduled(cron = "0 0 0 1 1 *")
+    @Scheduled(cron = "0 4,14,24,34,44,54 * * * *")
     public void updateYearly() {
-        log.info("[NORMAL] YEARLY 초기화 작업 시작: {}", LocalDateTime.now());
-        batchRunner.runNormalBatchAsync(Period.YEARLY);
+        redisLockUtil.executeWithLockWithRetry("normal-yearly-lock", 1, 300, () -> {
+            log.info("[NORMAL] YEARLY 초기화 작업 시작: {}", LocalDateTime.now());
+            batchRunner.runNormalBatch(Period.YEARLY);
+            return null;
+        });
     }
 
     // 한달에 한 번 (매월 1일 자정)
-    @Scheduled(cron = "0 0 0 1 * *")
+//    @Scheduled(cron = "0 0 0 1 * *")
+    @Scheduled(cron = "0 5,15,25,35,45,55 * * * *")
     public void updateVip() {
-        log.info("[VIP] MONTHLY 초기화 작업 시작: {}", LocalDateTime.now());
-        batchRunner.runVipBatchAsync();
+        redisLockUtil.executeWithLockWithRetry("vip-monthly-lock", 1, 300, () -> {
+            log.info("[VIP] MONTHLY 초기화 작업 시작: {}", LocalDateTime.now());
+            batchRunner.runVipBatch();
+            return null;
+        });
     }
 
     // 하루에 한 번 (매일 자정)
-    @Scheduled(cron = "0 0 0 * * *")
+//    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 6,16,26,36,46,56 * * * *")
     public void updateLocal() {
-        log.info("[LOCAL] DAILY 초기화 작업 시작: {}", LocalDateTime.now());
-        batchRunner.runLocalBatchAsync();
+        redisLockUtil.executeWithLockWithRetry("local-daily-lock", 1, 300, () -> {
+            log.info("[LOCAL] DAILY 초기화 작업 시작: {}", LocalDateTime.now());
+            batchRunner.runLocalBatch();
+            return null;
+        });
     }
 }

--- a/src/main/java/com/ureca/uble/global/schedule/batch/LocalBatchConfig.java
+++ b/src/main/java/com/ureca/uble/global/schedule/batch/LocalBatchConfig.java
@@ -1,0 +1,70 @@
+package com.ureca.uble.global.schedule.batch;
+
+import com.ureca.uble.domain.users.repository.UserRepository;
+import com.ureca.uble.entity.User;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class LocalBatchConfig {
+
+    private final UserRepository userRepository;
+    private final EntityManagerFactory entityManagerFactory;
+    private final TaskExecutor batchTaskExecutor;
+
+    @Bean(name = "localUpdateJob")
+    public Job localUpdateJob(JobRepository jobRepository, Step localUsageCountResetStep) {
+        return new JobBuilder("localUpdateJob", jobRepository)
+            .start(localUsageCountResetStep)
+            .build();
+    }
+
+    @Bean
+    public Step localUsageCountResetStep(JobRepository jobRepository, PlatformTransactionManager transactionManager,
+                                         ItemReader<User> localUserPagingReader, ItemWriter<User> localUserWriter) {
+        return new StepBuilder("localUsageCountResetStep", jobRepository)
+            .<User, User>chunk(100, transactionManager)
+            .reader(localUserPagingReader)
+            .writer(localUserWriter)
+            .taskExecutor(batchTaskExecutor)
+            .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<User> localUserPagingReader() {
+        JpaPagingItemReader<User> reader = new JpaPagingItemReader<>();
+        reader.setEntityManagerFactory(entityManagerFactory);
+        reader.setQueryString("SELECT u FROM User u WHERE u.isLocalAvailable = false ORDER BY u.id");
+        reader.setPageSize(100);
+        return reader;
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<User> localUserWriter() {
+        return users -> {
+            for (User user : users) {
+                user.updateLocalAvailability(true);
+            }
+            userRepository.saveAll(users);
+            log.info("[LOCAL] {}명의 LOCAL 혜택 사용 여부를 초기화", users.size());
+        };
+    }
+}

--- a/src/main/java/com/ureca/uble/global/schedule/batch/NormalBatchConfig.java
+++ b/src/main/java/com/ureca/uble/global/schedule/batch/NormalBatchConfig.java
@@ -57,7 +57,12 @@ public class NormalBatchConfig {
         @Value("#{jobParameters['period']}") String periodStr) {
         JpaPagingItemReader<Benefit> reader = new JpaPagingItemReader<>();
         reader.setEntityManagerFactory(entityManagerFactory);
-        reader.setQueryString("SELECT b FROM Benefit b WHERE b.period = :period AND b.rank = :rank");
+        reader.setQueryString(
+            "SELECT b FROM Benefit b " +
+                "JOIN b.brand br " +
+                "WHERE b.period = :period " +
+                "AND (br.rankType = 'NORMAL' OR (br.rankType = 'VIP_NORMAL' AND b.rank != 'VIP')) "
+        );
         reader.setParameterValues(Map.of(
             "period", Period.valueOf(periodStr),
             "rank", Rank.NORMAL

--- a/src/main/java/com/ureca/uble/global/schedule/batch/NormalBatchConfig.java
+++ b/src/main/java/com/ureca/uble/global/schedule/batch/NormalBatchConfig.java
@@ -1,0 +1,79 @@
+package com.ureca.uble.global.schedule.batch;
+
+import com.ureca.uble.domain.users.repository.UsageCountRepository;
+import com.ureca.uble.entity.Benefit;
+import com.ureca.uble.entity.enums.Period;
+import com.ureca.uble.entity.enums.Rank;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.Map;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class NormalBatchConfig {
+
+    private final UsageCountRepository usageCountRepository;
+    private final EntityManagerFactory entityManagerFactory;
+    private final TaskExecutor batchTaskExecutor;
+
+    @Bean(name = "normalUpdateJob")
+    public Job normalUpdateJob(JobRepository jobRepository, Step normalUsageCountResetStep) {
+        return new JobBuilder("normalUpdateJob", jobRepository)
+            .start(normalUsageCountResetStep)
+            .build();
+    }
+
+    @Bean
+    public Step normalUsageCountResetStep(JobRepository jobRepository, PlatformTransactionManager transactionManager,
+                                          ItemReader<Benefit> normalBenefitPagingReader, ItemWriter<Benefit> usageCountResetWriter) {
+        return new StepBuilder("normalUsageCountResetStep", jobRepository)
+            .<Benefit, Benefit>chunk(100, transactionManager)
+            .reader(normalBenefitPagingReader)
+            .writer(usageCountResetWriter)
+            .taskExecutor(batchTaskExecutor)
+            .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<Benefit> normalBenefitPagingReader(
+        @Value("#{jobParameters['period']}") String periodStr) {
+        JpaPagingItemReader<Benefit> reader = new JpaPagingItemReader<>();
+        reader.setEntityManagerFactory(entityManagerFactory);
+        reader.setQueryString("SELECT b FROM Benefit b WHERE b.period = :period AND b.rank = :rank");
+        reader.setParameterValues(Map.of(
+            "period", Period.valueOf(periodStr),
+            "rank", Rank.NORMAL
+        ));
+        reader.setPageSize(100);
+        return reader;
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<Benefit> usageCountResetWriter() {
+        return benefits -> {
+            for (Benefit benefit : benefits) {
+                int updated = usageCountRepository.resetCntByBenefitId(benefit.getId());
+                log.info("benefitId={} usageCount cnt 0으로 초기화 ({}건)", benefit.getId(), updated);
+            }
+        };
+    }
+}

--- a/src/main/java/com/ureca/uble/global/schedule/batch/NormalBatchConfig.java
+++ b/src/main/java/com/ureca/uble/global/schedule/batch/NormalBatchConfig.java
@@ -71,7 +71,7 @@ public class NormalBatchConfig {
     public ItemWriter<Benefit> usageCountResetWriter() {
         return benefits -> {
             for (Benefit benefit : benefits) {
-                int updated = usageCountRepository.resetCntByBenefitId(benefit.getId());
+                int updated = usageCountRepository.resetCountAndIsAvailableByBenefitId(benefit.getId());
                 log.info("benefitId={} usageCount cnt 0으로 초기화 ({}건)", benefit.getId(), updated);
             }
         };

--- a/src/main/java/com/ureca/uble/global/schedule/batch/UsageBatchRunner.java
+++ b/src/main/java/com/ureca/uble/global/schedule/batch/UsageBatchRunner.java
@@ -1,0 +1,68 @@
+package com.ureca.uble.global.schedule.batch;
+
+import com.ureca.uble.entity.enums.Period;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UsageBatchRunner {
+
+    private final JobLauncher jobLauncher;
+
+    private final Job normalUpdateJob;
+    private final Job vipUpdateJob;
+    private final Job localUpdateJob;
+
+    @Async
+    public void runNormalBatchAsync(Period period) {
+        try {
+            log.info("runNormalBatchAsyncRunner 실행");
+            jobLauncher.run(
+                normalUpdateJob,
+                new JobParametersBuilder()
+                    .addString("timestamp", String.valueOf(System.currentTimeMillis()))
+                    .addString("period", period.toString())
+                    .toJobParameters()
+            );
+        } catch (Exception e) {
+            log.error("기본 혜택 사용 내역 배치 실행 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    @Async
+    public void runVipBatchAsync() {
+        try {
+            log.info("runVipBatchAsyncRunner 실행");
+            jobLauncher.run(
+                vipUpdateJob,
+                new JobParametersBuilder()
+                    .addString("timestamp", String.valueOf(System.currentTimeMillis()))
+                    .toJobParameters()
+            );
+        } catch (Exception e) {
+            log.error("vip 사용 내역 배치 실행 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    @Async
+    public void runLocalBatchAsync() {
+        try {
+            log.info("runLocalBatchAsyncRunner 실행");
+            jobLauncher.run(
+                localUpdateJob,
+                new JobParametersBuilder()
+                    .addString("timestamp", String.valueOf(System.currentTimeMillis()))
+                    .toJobParameters()
+            );
+        } catch (Exception e) {
+            log.error("우리 동네 사용 내역 배치 실행 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/ureca/uble/global/schedule/batch/UsageBatchRunner.java
+++ b/src/main/java/com/ureca/uble/global/schedule/batch/UsageBatchRunner.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -20,8 +19,7 @@ public class UsageBatchRunner {
     private final Job vipUpdateJob;
     private final Job localUpdateJob;
 
-    @Async
-    public void runNormalBatchAsync(Period period) {
+    public void runNormalBatch(Period period) {
         try {
             log.info("runNormalBatchAsyncRunner 실행");
             jobLauncher.run(
@@ -36,8 +34,7 @@ public class UsageBatchRunner {
         }
     }
 
-    @Async
-    public void runVipBatchAsync() {
+    public void runVipBatch() {
         try {
             log.info("runVipBatchAsyncRunner 실행");
             jobLauncher.run(
@@ -51,8 +48,7 @@ public class UsageBatchRunner {
         }
     }
 
-    @Async
-    public void runLocalBatchAsync() {
+    public void runLocalBatch() {
         try {
             log.info("runLocalBatchAsyncRunner 실행");
             jobLauncher.run(

--- a/src/main/java/com/ureca/uble/global/schedule/batch/VipBatchConfig.java
+++ b/src/main/java/com/ureca/uble/global/schedule/batch/VipBatchConfig.java
@@ -1,0 +1,70 @@
+package com.ureca.uble.global.schedule.batch;
+
+import com.ureca.uble.domain.users.repository.UserRepository;
+import com.ureca.uble.entity.User;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class VipBatchConfig {
+
+    private final UserRepository userRepository;
+    private final EntityManagerFactory entityManagerFactory;
+    private final TaskExecutor batchTaskExecutor;
+
+    @Bean(name = "vipUpdateJob")
+    public Job vipUpdateJob(JobRepository jobRepository, Step vipUsageCountResetStep) {
+        return new JobBuilder("vipUpdateJob", jobRepository)
+            .start(vipUsageCountResetStep)
+            .build();
+    }
+
+    @Bean
+    public Step vipUsageCountResetStep(JobRepository jobRepository, PlatformTransactionManager transactionManager,
+                                       ItemReader<User> vipUserPagingReader, ItemWriter<User> vipUserWriter) {
+        return new StepBuilder("vipUsageCountResetStep", jobRepository)
+            .<User, User>chunk(100, transactionManager)
+            .reader(vipUserPagingReader)
+            .writer(vipUserWriter)
+            .taskExecutor(batchTaskExecutor)
+            .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<User> vipUserPagingReader() {
+        JpaPagingItemReader<User> reader = new JpaPagingItemReader<>();
+        reader.setEntityManagerFactory(entityManagerFactory);
+        reader.setQueryString("SELECT u FROM User u WHERE u.isVipAvailable = false ORDER BY u.id");
+        reader.setPageSize(100);
+        return reader;
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<User> vipUserWriter() {
+        return users -> {
+            for (User user : users) {
+                user.updateVipAvailability(true);
+            }
+            userRepository.saveAll(users);
+            log.info("[VIP] {}명의 VIP 혜택 사용 여부를 초기화", users.size());
+        };
+    }
+}

--- a/src/main/java/com/ureca/uble/global/schedule/util/RedisLockUtil.java
+++ b/src/main/java/com/ureca/uble/global/schedule/util/RedisLockUtil.java
@@ -1,0 +1,54 @@
+package com.ureca.uble.global.schedule.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisLockUtil {
+
+    private final RedissonClient redissonClient;
+
+    public <T> void executeWithLockWithRetry(String lockKey, long waitTime, long leaseTime, Supplier<T> task) {
+        RLock lock = redissonClient.getLock(lockKey);
+        int maxRetry = 3;
+        long retryDelay = 1000;
+        boolean isLocked = false;
+
+        try {
+            isLocked = lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS);
+            if (!isLocked) {
+                log.info("락 획득 실패: 다른 서버에서 실행 중이므로 종료");
+                return;
+            }
+
+            for (int atmp = 1; atmp <= maxRetry; atmp++) {
+                try {
+                    task.get();
+                    return;
+                } catch (Exception e) {
+                    log.warn("재시도 : ({}/{})", atmp + 1, maxRetry, e);
+                    if (atmp == maxRetry) {
+                        log.error("최대 재시도 횟수 초과, 종료합니다.");
+                        throw e;
+                    }
+                    Thread.sleep(retryDelay);
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            // 항상 락 해제
+            if (isLocked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,3 +3,6 @@ jwt:
     domain: localhost
     secure: false
     same-site: Lax
+
+redis:
+  ssl-enable: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,3 +3,6 @@ jwt:
     domain: .uplait.site
     secure: true
     same-site: None
+
+redis:
+  ssl-enable: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,13 @@ spring:
         mode: always
         encoding: UTF-8
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      ssl:
+        enabled: true
+
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${KAKAO_REDIRECT_URI}
@@ -31,5 +38,6 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-validity: 1800000
   refresh-token-validity: 604800000
+
 domain:
   base-url: ${DOMAIN_BASE_URL}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23 

## 📝작업 내용

- 일/주/월/년을 기준으로 이용 횟수를 초기화하는 스케줄러를 구현하였습니다. vip는 월 1회, local은 일 1회를 기준으로 초기화됩니다. 일반 혜택은 각 기준에 맞춰 초기화됩니다.
- 통신사는 유저가 매우 많기 때문에, 서버의 부담을 줄이기 위해 Spring batch를 적용하였습니다. (스케줄러가 batchRunner를 호출)
- dev/main 서버가 동시에 스케줄러를 호출하는 문제를 막기 위해 redisson 분산락을 적용하였습니다.
- redis 활용을 위해 elasticache를 새롭게 띄우고 연결하였습니다. (상세 노션 참고)

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- 실제 운영 환경에서 분산 락 적용을 확인하기 위해 임시 cron식을 설정해두었습니다. 문제가 없다면 추후 수정할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 배치 작업 및 스케줄링 기능이 추가되어 일/주/월/연 단위, VIP, 로컬 사용량 초기화 작업이 자동 실행됩니다.
  * Redis 연동 및 분산 락 기능이 도입되어 안정적인 동시성 제어가 가능합니다.
  * Redis 및 Redisson 설정이 추가되어 캐싱 및 메시징, 데이터 접근이 지원됩니다.

* **환경설정**
  * Docker 환경에 Redis 서비스가 추가되었습니다.
  * 개발/운영 환경별 Redis 및 SSL 설정이 반영되었습니다.

* **문서화**
  * 일부 API 파라미터 설명이 보강되었습니다.

* **버그 수정**
  * 해당 없음

* **기타**
  * 새로운 저장소 메서드 및 배치 관련 설정 클래스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->