### PR TITLE
[Fix] 이용 내역 등록 로직 수정

### DIFF
--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepository.java
@@ -1,6 +1,7 @@
 package com.ureca.uble.domain.store.repository;
 
 import com.ureca.uble.entity.Store;
+import com.ureca.uble.entity.enums.BenefitType;
 import com.ureca.uble.entity.enums.Season;
 import org.locationtech.jts.geom.Point;
 
@@ -8,4 +9,5 @@ import java.util.List;
 
 public interface CustomStoreRepository {
     List<Store> findStoresByFiltering(Point curPoint, int distance, Long categoryId, Long brandId, Season season, Boolean isLocal);
+    Boolean checkStoreBenefitByType(Long storeId, BenefitType type);
 }

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -2,8 +2,14 @@ package com.ureca.uble.domain.store.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.uble.entity.QBenefit;
+import com.ureca.uble.entity.QBrand;
 import com.ureca.uble.entity.Store;
+import com.ureca.uble.entity.enums.BenefitType;
+import com.ureca.uble.entity.enums.Rank;
+import com.ureca.uble.entity.enums.RankType;
 import com.ureca.uble.entity.enums.Season;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
@@ -11,6 +17,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.ureca.uble.entity.QBenefit.benefit;
 import static com.ureca.uble.entity.QBrand.brand;
 import static com.ureca.uble.entity.QStore.store;
 
@@ -20,6 +27,9 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    /**
+     * 근처 매장 정보 조회
+     */
     @Override
     public List<Store> findStoresByFiltering(Point curPoint, int distance, Long categoryId, Long brandId, Season season, Boolean isLocal) {
         return jpaQueryFactory
@@ -34,6 +44,43 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
                 isLocalEq(isLocal)
             )
             .fetch();
+    }
+
+    /**
+     * 매장에서 이용 가능한 혜택인지 판별
+     */
+    public Boolean checkStoreBenefitByType(Long storeId, BenefitType type) {
+        return jpaQueryFactory
+            .select(store.id)
+            .from(store)
+            .join(store.brand, brand)
+            .where(
+                store.id.eq(storeId),
+                getCondition(brand, benefit, type)
+            )
+            .fetchFirst() != null;
+    }
+
+    public BooleanExpression getCondition(QBrand brand, QBenefit benefit, BenefitType type) {
+        return switch (type) {
+            case VIP -> brand.rankType.eq(RankType.VIP)
+                .or(brand.rankType.eq(RankType.VIP_NORMAL).and(
+                    JPAExpressions.selectOne()
+                        .from(benefit)
+                        .where(benefit.brand.eq(brand)
+                            .and(benefit.rank.eq(Rank.VIP)))
+                        .exists()
+                ));
+            case NORMAL -> brand.rankType.eq(RankType.NORMAL)
+                .or(brand.rankType.eq(RankType.VIP_NORMAL).and(
+                    JPAExpressions.selectOne()
+                        .from(benefit)
+                        .where(benefit.brand.eq(brand)
+                            .and(benefit.rank.eq(Rank.VIP)))
+                        .notExists()
+                ));
+            case LOCAL -> brand.isLocal.isTrue();
+        };
     }
 
     private BooleanExpression withinRadius(Point curPoint, int distance) {

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -56,12 +56,12 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
             .join(store.brand, brand)
             .where(
                 store.id.eq(storeId),
-                getCondition(brand, benefit, type)
+                getCondition(type)
             )
             .fetchFirst() != null;
     }
 
-    public BooleanExpression getCondition(QBrand brand, QBenefit benefit, BenefitType type) {
+    public BooleanExpression getCondition(BenefitType type) {
         return switch (type) {
             case VIP -> brand.rankType.eq(RankType.VIP)
                 .or(brand.rankType.eq(RankType.VIP_NORMAL).and(

--- a/src/main/java/com/ureca/uble/domain/users/service/UsageHistoryService.java
+++ b/src/main/java/com/ureca/uble/domain/users/service/UsageHistoryService.java
@@ -51,6 +51,11 @@ public class UsageHistoryService {
 		User user = findUser(userId);
 		Store store = findStore(storeId);
 
+		// store 검증
+		if(!storeRepository.checkStoreBenefitByType(storeId, req.getBenefitType())) {
+			throw new GlobalException(BENEFIT_NOT_AVAILABLE);
+		};
+
 		// 등급에 따른 추가 작업 처리
 		switch (req.getBenefitType()) {
 			case VIP -> handleVipBenefit(user);


### PR DESCRIPTION
## #️⃣연관된 이슈
> #35 

## 📝작업 내용
- 이용 내역 등록 시 매장을 검증하는 로직을 추가하였습니다.
- QueryDSL을 통해 하나의 메소드로 각 타입을 검증할 수 있도록 구현하였습니다.


## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 매장별로 특정 혜택 유형(VIP, 일반, 로컬) 지원 여부를 확인하는 기능이 추가되었습니다.
  * 사용 이력 생성 시, 매장이 요청한 혜택 유형을 지원하지 않으면 오류가 발생하도록 검증이 강화되었습니다.

* **버그 수정**
  * 사용 이력 생성 과정에서 매장 혜택 지원 여부 미검증 문제를 해결하였습니다.

* **테스트**
  * 매장이 요청한 혜택 유형을 지원하지 않을 때 오류가 발생하는 시나리오에 대한 테스트가 추가되었습니다.
  * 기존 테스트에서 불필요한 모의 객체가 제거되고, 혜택 유형 지원 여부에 대한 모의 동작이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->