### PR TITLE
[Fix] 전체 매장 리스트 조회 수정

### DIFF
--- a/src/main/java/com/ureca/uble/domain/store/controller/StoreController.java
+++ b/src/main/java/com/ureca/uble/domain/store/controller/StoreController.java
@@ -2,6 +2,7 @@ package com.ureca.uble.domain.store.controller;
 
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
 import com.ureca.uble.domain.store.service.StoreService;
+import com.ureca.uble.entity.enums.BenefitType;
 import com.ureca.uble.entity.enums.Season;
 import com.ureca.uble.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +29,7 @@ public class StoreController {
      * @param categoryId 카테고리 id
      * @param brandId 제휴처 id
      * @param season 계절 정보
-     * @param isLocal 우리 동네 여부
+     * @param type 혜택 종류 정보
      */
     @Operation(summary = "근처 매장 정보 조회", description = "근처 매장 정보 조회")
     @GetMapping
@@ -45,9 +46,9 @@ public class StoreController {
         @RequestParam(required = false) Long brandId,
         @Parameter(description = "계절 필터링")
         @RequestParam(required = false) Season season,
-        @Parameter(description = "우리 동네 필터링")
-        @RequestParam(required = false) Boolean isLocal) {
-        return CommonResponse.success(storeService.getStores(latitude, longitude, distance, categoryId, brandId, season, isLocal));
+        @Parameter(description = "혜택 타입 필터링(LOCAL/VIP)")
+        @RequestParam(required = false) BenefitType type) {
+        return CommonResponse.success(storeService.getStores(latitude, longitude, distance, categoryId, brandId, season, type));
     }
 
 }

--- a/src/main/java/com/ureca/uble/domain/store/dto/response/GetStoreRes.java
+++ b/src/main/java/com/ureca/uble/domain/store/dto/response/GetStoreRes.java
@@ -15,6 +15,9 @@ public class GetStoreRes {
     @Schema(description = "매장 이름", example = "CGV 강남")
     private String storeName;
 
+    @Schema(description = "카테고리", example = "문화/여가")
+    private String category;
+
     @Schema(description = "위도", example = "37.5017831")
     private Double latitude;
 
@@ -25,6 +28,7 @@ public class GetStoreRes {
         return GetStoreRes.builder()
             .storeId(store.getId())
             .storeName(store.getName())
+            .category(store.getBrand().getCategory().getName())
             .latitude(store.getLocation().getY())
             .longitude(store.getLocation().getX())
             .build();

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepository.java
@@ -8,6 +8,6 @@ import org.locationtech.jts.geom.Point;
 import java.util.List;
 
 public interface CustomStoreRepository {
-    List<Store> findStoresByFiltering(Point curPoint, int distance, Long categoryId, Long brandId, Season season, Boolean isLocal);
+    List<Store> findStoresByFiltering(Point curPoint, int distance, Long categoryId, Long brandId, Season season, BenefitType type);
     Boolean checkStoreBenefitByType(Long storeId, BenefitType type);
 }

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -102,7 +102,6 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
     }
 
     private BooleanExpression typeEq(BenefitType type) {
-        if(type == null) return null;
-        return getCondition(type);
+        return type == null ? null : getCondition(type);
     }
 }

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -4,8 +4,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.ureca.uble.entity.QBenefit;
-import com.ureca.uble.entity.QBrand;
 import com.ureca.uble.entity.Store;
 import com.ureca.uble.entity.enums.BenefitType;
 import com.ureca.uble.entity.enums.Rank;
@@ -19,6 +17,7 @@ import java.util.List;
 
 import static com.ureca.uble.entity.QBenefit.benefit;
 import static com.ureca.uble.entity.QBrand.brand;
+import static com.ureca.uble.entity.QCategory.category;
 import static com.ureca.uble.entity.QStore.store;
 
 @Repository
@@ -31,17 +30,18 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
      * 근처 매장 정보 조회
      */
     @Override
-    public List<Store> findStoresByFiltering(Point curPoint, int distance, Long categoryId, Long brandId, Season season, Boolean isLocal) {
+    public List<Store> findStoresByFiltering(Point curPoint, int distance, Long categoryId, Long brandId, Season season, BenefitType type) {
         return jpaQueryFactory
             .select(store)
             .from(store)
-            .innerJoin(store.brand, brand)
+            .innerJoin(store.brand, brand).fetchJoin()
+            .innerJoin(brand.category, category).fetchJoin()
             .where(
                 withinRadius(curPoint, distance),
                 categoryIdEq(categoryId),
                 brandIdEq(brandId),
                 seasonEq(season),
-                isLocalEq(isLocal)
+                typeEq(type)
             )
             .fetch();
     }
@@ -101,7 +101,8 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
         return season == null ? null : brand.season.eq(season);
     }
 
-    private BooleanExpression isLocalEq(Boolean isLocal) {
-        return isLocal == null ? null : brand.isLocal.eq(isLocal);
+    private BooleanExpression typeEq(BenefitType type) {
+        if(type == null) return null;
+        return getCondition(type);
     }
 }

--- a/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
+++ b/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
@@ -3,6 +3,7 @@ package com.ureca.uble.domain.store.service;
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreRes;
 import com.ureca.uble.domain.store.repository.StoreRepository;
+import com.ureca.uble.entity.enums.BenefitType;
 import com.ureca.uble.entity.enums.Season;
 import com.ureca.uble.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
@@ -26,11 +27,11 @@ public class StoreService {
     /**
      * 근처 매장 정보 조회
      */
-    public GetStoreListRes getStores(double latitude, double longitude, int distance, Long categoryId, Long brandId, Season season, Boolean isLocal) {
+    public GetStoreListRes getStores(double latitude, double longitude, int distance, Long categoryId, Long brandId, Season season, BenefitType type) {
         validateRange(latitude, longitude, distance);
 
         Point curPoint = getPoint(latitude, longitude);
-        List<GetStoreRes> storeList = storeRepository.findStoresByFiltering(curPoint, distance, categoryId, brandId, season, isLocal)
+        List<GetStoreRes> storeList = storeRepository.findStoresByFiltering(curPoint, distance, categoryId, brandId, season, type)
             .stream().map(GetStoreRes::from).toList();
 
         return new GetStoreListRes(storeList);

--- a/src/test/java/com/ureca/uble/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/store/service/StoreServiceTest.java
@@ -3,6 +3,7 @@ package com.ureca.uble.domain.store.service;
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
 import com.ureca.uble.domain.store.repository.StoreRepository;
 import com.ureca.uble.entity.Store;
+import com.ureca.uble.entity.enums.BenefitType;
 import com.ureca.uble.entity.enums.Season;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ class StoreServiceTest {
         Long categoryId = null;
         Long brandId = null;
         Season season = null;
-        Boolean isLocal = null;
+        BenefitType type = null;
 
         Store mockStore = mock(Store.class);
         when(mockStore.getId()).thenReturn(1L);
@@ -58,7 +59,7 @@ class StoreServiceTest {
             .thenReturn(List.of(mockStore));
 
         // when
-        GetStoreListRes result = storeService.getStores(testPoint.getY(), testPoint.getX(), distance, categoryId, brandId, season, isLocal);
+        GetStoreListRes result = storeService.getStores(testPoint.getY(), testPoint.getX(), distance, categoryId, brandId, season, type);
 
         // then
         assertNotNull(result);

--- a/src/test/java/com/ureca/uble/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/store/service/StoreServiceTest.java
@@ -2,6 +2,8 @@ package com.ureca.uble.domain.store.service;
 
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
 import com.ureca.uble.domain.store.repository.StoreRepository;
+import com.ureca.uble.entity.Brand;
+import com.ureca.uble.entity.Category;
 import com.ureca.uble.entity.Store;
 import com.ureca.uble.entity.enums.BenefitType;
 import com.ureca.uble.entity.enums.Season;
@@ -50,9 +52,15 @@ class StoreServiceTest {
         BenefitType type = null;
 
         Store mockStore = mock(Store.class);
+        Brand mockBrand = mock(Brand.class);
+        Category mockCategory = mock(Category.class);
+
         when(mockStore.getId()).thenReturn(1L);
         when(mockStore.getName()).thenReturn("테스트 선릉점");
         when(mockStore.getLocation()).thenReturn(storeLocation);
+        when(mockStore.getBrand()).thenReturn(mockBrand);
+        when(mockBrand.getCategory()).thenReturn(mockCategory);
+        when(mockCategory.getName()).thenReturn("푸드");
 
         when(storeRepository.findStoresByFiltering(
             any(Point.class), anyInt(), any(), any(), any(), any()))


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38 

## 📝작업 내용
- 전체 매장 조회 시 혜택 종류에 따른 필터링이 가능하도록 수정하였습니다. (VIP / LOCAL 등)
- 반환 DTO에 카테고리 정보를 추가하였습니다.
- 카테고리 정보를 가져오기 위해 store → brand → category 순으로 조회가 필요 : 쿼리가 여러 번 발생하는 것을 방지하기 위해 fetch join을 사용하였습니다.

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매장 목록 조회 시 기존의 '우리 동네 여부' Boolean 필터가 '혜택 타입(BenefitType)' 필터로 변경되어, LOCAL 또는 VIP 등 다양한 혜택 기준으로 매장을 필터링할 수 있습니다.
  * 매장 정보 응답에 카테고리명이 추가되어, 매장별 카테고리 정보를 확인할 수 있습니다.

* **버그 수정**
  * 해당 없음

* **테스트**
  * 서비스 테스트가 새로운 '혜택 타입' 필터에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->