### PR TITLE
[UBLE-26] feat: 피드백 생성 API 구현

### DIFF
--- a/src/main/java/com/ureca/uble/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/ureca/uble/domain/feedback/controller/FeedbackController.java
@@ -1,0 +1,45 @@
+package com.ureca.uble.domain.feedback.controller;
+
+import com.ureca.uble.domain.feedback.dto.request.CreateFeedbackReq;
+import com.ureca.uble.domain.feedback.dto.response.CreateFeedbackRes;
+import com.ureca.uble.domain.feedback.service.FeedbackService;
+import com.ureca.uble.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/users/feedback")
+@RequiredArgsConstructor
+public class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    /**
+     * 서비스 피드백 등록
+     *
+     * @param userId 로그인한 사용자의 ID
+     * @param req       제목(title), 내용(content), 별점(score) 필드를 담은 요청 객체
+     * @return 등록된 피드백 ID를 담은 CommonResponse
+     */
+    @Operation(summary = "서비스 피드백 등록", description = "사용자가 제목·내용·평점을 입력해 피드백을 남깁니다.")
+    @PostMapping
+    public CommonResponse<CreateFeedbackRes> createFeedback(
+            @Parameter(description = "사용자정보", required = true)
+            @AuthenticationPrincipal Long userId,
+
+            @Parameter(description = "제목(title), 내용(content), 별점1~5(score)을 담은 요청 객체", required = true)
+
+            @Validated @RequestBody CreateFeedbackReq req
+    ) {
+        Long feedbackId = feedbackService.createFeedback(userId, req);
+        return CommonResponse.success(new CreateFeedbackRes(feedbackId));
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/ureca/uble/domain/feedback/controller/FeedbackController.java
@@ -34,12 +34,10 @@ public class FeedbackController {
     public CommonResponse<CreateFeedbackRes> createFeedback(
             @Parameter(description = "사용자정보", required = true)
             @AuthenticationPrincipal Long userId,
-
             @Parameter(description = "제목(title), 내용(content), 별점1~5(score)을 담은 요청 객체", required = true)
-
             @Validated @RequestBody CreateFeedbackReq req
     ) {
-        Long feedbackId = feedbackService.createFeedback(userId, req);
-        return CommonResponse.success(new CreateFeedbackRes(feedbackId));
+        CreateFeedbackRes res = feedbackService.createFeedback(userId, req);
+        return CommonResponse.success(res);
     }
 }

--- a/src/main/java/com/ureca/uble/domain/feedback/dto/request/CreateFeedbackReq.java
+++ b/src/main/java/com/ureca/uble/domain/feedback/dto/request/CreateFeedbackReq.java
@@ -1,0 +1,30 @@
+package com.ureca.uble.domain.feedback.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "서비스 피드백 생성 요청 DTO")
+public class CreateFeedbackReq {
+
+    @Schema(description = "피드백 제목 (100자 이내)", example = "앱 사용성이 좋습니다.")
+    @NotBlank
+    @Size(max = 100)
+    private String title;
+
+    @Schema(description = "피드백 내용 (200자 이내)", example = "지도 기능이 직관적이라 너무 편리해요!")
+    @NotBlank
+    @Size(max = 200)
+    private String content;
+
+    @Schema(description = "평점 (1~5)", example = "5")
+    @Min(value = 1)
+    @Max(value = 5)
+    private int score;
+}

--- a/src/main/java/com/ureca/uble/domain/feedback/dto/response/CreateFeedbackRes.java
+++ b/src/main/java/com/ureca/uble/domain/feedback/dto/response/CreateFeedbackRes.java
@@ -1,0 +1,15 @@
+package com.ureca.uble.domain.feedback.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "서비스 피드백 생성 응답 DTO")
+public class CreateFeedbackRes {
+
+    @Schema(description = "생성된 피드백 ID", example = "123")
+    private final Long feedbackId;
+}

--- a/src/main/java/com/ureca/uble/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/ureca/uble/domain/feedback/service/FeedbackService.java
@@ -1,11 +1,13 @@
 package com.ureca.uble.domain.feedback.service;
 
 import com.ureca.uble.domain.feedback.dto.request.CreateFeedbackReq;
+import com.ureca.uble.domain.feedback.dto.response.CreateFeedbackRes;
 import com.ureca.uble.domain.feedback.repository.FeedbackRepository;
 import com.ureca.uble.domain.users.repository.UserRepository;
 import com.ureca.uble.entity.Feedback;
 import com.ureca.uble.entity.User;
 import com.ureca.uble.global.exception.GlobalException;
+import com.ureca.uble.global.response.CommonResponse;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,14 +26,12 @@ public class FeedbackService {
     /**
      * 피드백 생성 후 생성된 ID 반환
      */
-    public Long createFeedback(Long userId, CreateFeedbackReq req) {
+    public CreateFeedbackRes createFeedback(Long userId, CreateFeedbackReq req) {
         User user = findUser(userId);
-
         Feedback feedback = Feedback.of(user, req);
+        Long feedbackId = feedbackRepository.save(feedback).getId();
 
-        return feedbackRepository
-                .save(feedback)
-                .getId();
+        return new CreateFeedbackRes(feedbackId);
     }
 
     /**

--- a/src/main/java/com/ureca/uble/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/ureca/uble/domain/feedback/service/FeedbackService.java
@@ -7,7 +7,6 @@ import com.ureca.uble.domain.users.repository.UserRepository;
 import com.ureca.uble.entity.Feedback;
 import com.ureca.uble.entity.User;
 import com.ureca.uble.global.exception.GlobalException;
-import com.ureca.uble.global.response.CommonResponse;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +15,6 @@ import static com.ureca.uble.domain.users.exception.UserErrorCode.USER_NOT_FOUND
 
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class FeedbackService {
 
@@ -26,6 +24,7 @@ public class FeedbackService {
     /**
      * 피드백 생성 후 생성된 ID 반환
      */
+    @Transactional
     public CreateFeedbackRes createFeedback(Long userId, CreateFeedbackReq req) {
         User user = findUser(userId);
         Feedback feedback = Feedback.of(user, req);

--- a/src/main/java/com/ureca/uble/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/ureca/uble/domain/feedback/service/FeedbackService.java
@@ -1,0 +1,44 @@
+package com.ureca.uble.domain.feedback.service;
+
+import com.ureca.uble.domain.feedback.dto.request.CreateFeedbackReq;
+import com.ureca.uble.domain.feedback.repository.FeedbackRepository;
+import com.ureca.uble.domain.users.repository.UserRepository;
+import com.ureca.uble.entity.Feedback;
+import com.ureca.uble.entity.User;
+import com.ureca.uble.global.exception.GlobalException;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.ureca.uble.domain.users.exception.UserErrorCode.USER_NOT_FOUND;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FeedbackService {
+
+    private final FeedbackRepository feedbackRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 피드백 생성 후 생성된 ID 반환
+     */
+    public Long createFeedback(Long userId, CreateFeedbackReq req) {
+        User user = findUser(userId);
+
+        Feedback feedback = Feedback.of(user, req);
+
+        return feedbackRepository
+                .save(feedback)
+                .getId();
+    }
+
+    /**
+     * userId로 User 조회, 없으면 USER_NOT_FOUND 예외 던짐
+     */
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/ureca/uble/entity/Feedback.java
+++ b/src/main/java/com/ureca/uble/entity/Feedback.java
@@ -1,5 +1,6 @@
 package com.ureca.uble.entity;
 
+import com.ureca.uble.domain.feedback.dto.request.CreateFeedbackReq;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,10 +25,23 @@ public class Feedback extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
+    @Column(nullable = false)
+    private int score;
+
     @Builder(access = PRIVATE)
-    private Feedback(User user, String title, String content) {
+    private Feedback(User user, String title, String content, int score) {
         this.user = user;
         this.title = title;
         this.content = content;
+        this.score = score;
+    }
+
+    public static Feedback of(User user, CreateFeedbackReq req) {
+        return Feedback.builder()
+                .user(user)
+                .title(req.getTitle())
+                .content(req.getContent())
+                .score(req.getScore())
+                .build();
     }
 }

--- a/src/test/java/com/ureca/uble/domain/feedback/FeedbackServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/feedback/FeedbackServiceTest.java
@@ -1,6 +1,7 @@
 package com.ureca.uble.domain.feedback.service;
 
 import com.ureca.uble.domain.feedback.dto.request.CreateFeedbackReq;
+import com.ureca.uble.domain.feedback.dto.response.CreateFeedbackRes;
 import com.ureca.uble.domain.feedback.repository.FeedbackRepository;
 import com.ureca.uble.domain.users.repository.UserRepository;
 import com.ureca.uble.entity.Feedback;
@@ -47,7 +48,8 @@ class FeedbackServiceTest {
                 .thenReturn(mockFeedback);
 
         // when
-        Long result = feedbackService.createFeedback(userId, req);
+        CreateFeedbackRes res = feedbackService.createFeedback(userId, req);
+        Long result = res.getFeedbackId();
 
         // then
         assertNotNull(result);

--- a/src/test/java/com/ureca/uble/domain/feedback/FeedbackServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/feedback/FeedbackServiceTest.java
@@ -1,0 +1,73 @@
+package com.ureca.uble.domain.feedback.service;
+
+import com.ureca.uble.domain.feedback.dto.request.CreateFeedbackReq;
+import com.ureca.uble.domain.feedback.repository.FeedbackRepository;
+import com.ureca.uble.domain.users.repository.UserRepository;
+import com.ureca.uble.entity.Feedback;
+import com.ureca.uble.entity.User;
+import com.ureca.uble.global.exception.GlobalException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.ureca.uble.domain.users.exception.UserErrorCode.USER_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedbackServiceTest {
+
+    @Mock private FeedbackRepository feedbackRepository;
+    @Mock private UserRepository userRepository;
+    @InjectMocks private FeedbackService feedbackService;
+
+    @Test
+    @DisplayName("유효한 사용자 ID와 피드백 정보로 피드백을 성공적으로 생성한다.")
+    void createFeedback_success_check() {
+        // given
+        Long userId = 1L;
+        CreateFeedbackReq req = mock(CreateFeedbackReq.class);
+        when(req.getTitle()).thenReturn("앱 사용성이 좋습니다.");
+        when(req.getContent()).thenReturn("지도 기능이 직관적이라 너무 편리해요!");
+        when(req.getScore()).thenReturn(5);
+
+        User mockUser = mock(User.class);
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(mockUser));
+
+        Feedback mockFeedback = mock(Feedback.class);
+        when(mockFeedback.getId()).thenReturn(1L);
+        when(feedbackRepository.save(any(Feedback.class)))
+                .thenReturn(mockFeedback);
+
+        // when
+        Long result = feedbackService.createFeedback(userId, req);
+
+        // then
+        assertNotNull(result);
+        assertEquals(1L, result);
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 ID로 피드백 생성 시 USER_NOT_FOUND 예외를 던진다.")
+    void createFeedback_userNotFound_exception() {
+        // given
+        Long userId = 999L;
+        CreateFeedbackReq req = mock(CreateFeedbackReq.class);
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        GlobalException exception = assertThrows(GlobalException.class,
+                () -> feedbackService.createFeedback(userId, req)
+        );
+        assertEquals(USER_NOT_FOUND, exception.getResultCode());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #36 

## 📝작업 내용

- 클라이언트로부터 `memberId`, `content`, `score`(평점)를 받아 `Feedback` 엔티티에 저장하고 생성된 피드백 정보를 반환합니다.
- 평점 저장을 위해 `score` 필드를 `Feedback` 엔티티에 추가 
- 잘못된 요청에 대해 `FeedbackErrorCode` 기반 예외 처리 로직을 적용했습니다.
- `Feedback` 엔티티에 `score` 필드 추가했습니다.
- `FeedbackService`와 `FeedbackServiceImpl`에 모듈화하여 책임을 분리했습니다. 
- 단위 테스트(`FeedbackServiceTest`)를 작성하여 정상 생성 및 예외 케이스를 모두 검증했습니다.


## 📷스크린샷 (선택)
<img width="752" height="851" alt="스크린샷 2025-07-12 오후 3 45 22" src="https://github.com/user-attachments/assets/9456c394-1e96-46f2-81e9-665a1045433e" />



## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 서비스 피드백을 생성할 수 있는 REST API 엔드포인트가 추가되었습니다. (제목, 내용, 점수 입력 가능)
  * 피드백 생성 시 성공적으로 등록된 피드백 ID를 반환합니다.

* **버그 수정**
  * 없음

* **테스트**
  * 피드백 생성 서비스에 대한 성공 및 예외 상황 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->