### PR TITLE
[Feat] 매장 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/ureca/uble/domain/brand/repository/BenefitRepository.java
+++ b/src/main/java/com/ureca/uble/domain/brand/repository/BenefitRepository.java
@@ -1,13 +1,10 @@
 package com.ureca.uble.domain.brand.repository;
 
 import com.ureca.uble.entity.Benefit;
-import com.ureca.uble.entity.enums.Period;
-import com.ureca.uble.entity.enums.Rank;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface BenefitRepository extends JpaRepository<Benefit, Long> {
@@ -23,6 +20,4 @@ public interface BenefitRepository extends JpaRepository<Benefit, Long> {
         LIMIT 1
     """, nativeQuery = true)
     Optional<Benefit> findNormalBenefitByStoreId(@Param("storeId") Long storeId);
-
-    List<Benefit> findAllByPeriodAndRank(Period period, Rank rank);
 }

--- a/src/main/java/com/ureca/uble/domain/store/controller/StoreController.java
+++ b/src/main/java/com/ureca/uble/domain/store/controller/StoreController.java
@@ -1,5 +1,6 @@
 package com.ureca.uble.domain.store.controller;
 
+import com.ureca.uble.domain.store.dto.response.GetStoreDetailRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
 import com.ureca.uble.domain.store.service.StoreService;
 import com.ureca.uble.entity.enums.BenefitType;
@@ -8,10 +9,8 @@ import com.ureca.uble.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/stores")
@@ -51,4 +50,25 @@ public class StoreController {
         return CommonResponse.success(storeService.getStores(latitude, longitude, distance, categoryId, brandId, season, type));
     }
 
+    /**
+     * 매장 상세 정보 조회
+     *
+     * @param latitude 위도
+     * @param longitude 경도
+     * @param userId 사용자 정보
+     * @param storeId 매장 id
+     */
+    @Operation(summary = "매장 상세 정보 조회", description = "매장 상세 정보 조회")
+    @GetMapping("/{storeId}")
+    public CommonResponse<GetStoreDetailRes> getStoreDetail(
+        @Parameter(description = "위도", required = true)
+        @RequestParam double latitude,
+        @Parameter(description = "경도", required = true)
+        @RequestParam double longitude,
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal Long userId,
+        @Parameter(description = "매장 id", required = true)
+        @PathVariable Long storeId) {
+        return CommonResponse.success(storeService.getStoreDetail(latitude, longitude, userId, storeId));
+    }
 }

--- a/src/main/java/com/ureca/uble/domain/store/dto/response/GetBenefitInfoRes.java
+++ b/src/main/java/com/ureca/uble/domain/store/dto/response/GetBenefitInfoRes.java
@@ -1,0 +1,53 @@
+package com.ureca.uble.domain.store.dto.response;
+
+import com.ureca.uble.entity.Benefit;
+import com.ureca.uble.entity.enums.BenefitType;
+import com.ureca.uble.entity.enums.Period;
+import com.ureca.uble.entity.enums.Rank;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "혜택 정보 반환 DTO")
+public class GetBenefitInfoRes {
+    @Schema(description = "혜택 id", example = "1")
+    private Long benefitId;
+
+    @Schema(description = "혜택 종류", example = "NORMAL")
+    private String type;
+
+    @Schema(description = "혜택 사용 가능 최소 등급", example = "NORMAL")
+    private String minRank;
+
+    @Schema(description = "혜택 정보", example = "패밀리 사이즈(5가지 맛) 4천원 할인")
+    private String content;
+
+    @Schema(description = "이용 방법", example = "U+ 멤버십 앱 메인 화면에서 검색 후 쿠폰 다운")
+    private String manual;
+
+    @Schema(description = "제공 횟수", example = "월 1회")
+    private String provisionCount;
+
+    public static GetBenefitInfoRes of(Benefit benefit, BenefitType type) {
+        return GetBenefitInfoRes.builder()
+            .benefitId(benefit.getId())
+            .type(type.name())
+            .minRank(benefit.getRank() == Rank.NONE ? "VIP" : benefit.getRank().toString())
+            .content(benefit.getContent())
+            .manual(benefit.getManual())
+            .provisionCount(getProvisionString(benefit.getPeriod(), benefit.getNumber()))
+            .build();
+    }
+
+    private static String getProvisionString(Period period, Integer number) {
+        return switch (period) {
+            case DAILY -> "일 " + number + "회";
+            case WEEKLY -> "주 " + number + "회";
+            case MONTHLY -> "월 " + number + "회";
+            case YEARLY -> "연 " + number + "회";
+            case NONE -> "제한 없음";
+        };
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/store/dto/response/GetStoreDetailRes.java
+++ b/src/main/java/com/ureca/uble/domain/store/dto/response/GetStoreDetailRes.java
@@ -1,0 +1,71 @@
+package com.ureca.uble.domain.store.dto.response;
+
+import com.ureca.uble.entity.Store;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "매장 상세 정보 반환 DTO")
+public class GetStoreDetailRes {
+    @Schema(description = "제휴처 id", example = "123")
+    private Long brandId;
+
+    @Schema(description = "매장 id", example = "123")
+    private Long storeId;
+
+    @Schema(description = "매장 이름", example = "스타벅스 선릉점")
+    private String storeName;
+
+    @Schema(description = "매장 설명", example = "커피가 맛있는 스타벅스")
+    private String description;
+
+    @Schema(description = "매장 주소", example = "서울 강남구 테헤란로64길 18")
+    private String address;
+
+    @Schema(description = "매장 대표 연락처", example = "02-1234-5678")
+    private String phoneNumber;
+
+    @Schema(description = "매장까지의 거리 (m 기준)", example = "900.123")
+    private Double distance;
+
+    @Schema(description = "카테고리", example = "음식점")
+    private String category;
+
+    @Schema(description = "대표 이미지 URL", example = "https://example.com")
+    private String imageUrl;
+
+    @Schema(description = "(사용자) 기본 혜택 사용 가능 여부", example = "true")
+    private boolean isNormalAvailable;
+
+    @Schema(description = "(사용자) VIP 콕 혜택 사용 가능 여부", example = "true")
+    private boolean isVipAvailable;
+
+    @Schema(description = "(사용자) 우리 동네 멤버십 혜택 사용 가능 여부", example = "false")
+    private boolean isLocalAvailable;
+
+    @Schema(description = "혜택 리스트", example = "혜택 리스트")
+    private List<GetBenefitInfoRes> benefitList;
+
+    public static GetStoreDetailRes of(Store store,Double distance, boolean isNormalAvailable, boolean isVipAvailable,
+                                       boolean isLocalAvailable, List<GetBenefitInfoRes> benefitList) {
+        return GetStoreDetailRes.builder()
+            .brandId(store.getBrand().getId())
+            .storeId(store.getId())
+            .storeName(store.getName())
+            .description(store.getBrand().getDescription())
+            .address(store.getAddress())
+            .phoneNumber(store.getPhoneNumber())
+            .distance(distance)
+            .category(store.getBrand().getCategory().getName())
+            .imageUrl(store.getBrand().getImageUrl())
+            .isNormalAvailable(isNormalAvailable)
+            .isVipAvailable(isVipAvailable)
+            .isLocalAvailable(isLocalAvailable)
+            .benefitList(benefitList)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepository.java
@@ -9,5 +9,4 @@ import java.util.List;
 
 public interface CustomStoreRepository {
     List<Store> findStoresByFiltering(Point curPoint, int distance, Long categoryId, Long brandId, Season season, BenefitType type);
-    Boolean checkStoreBenefitByType(Long storeId, BenefitType type);
 }

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -64,21 +64,9 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
     public BooleanExpression getCondition(BenefitType type) {
         return switch (type) {
             case VIP -> brand.rankType.eq(RankType.VIP)
-                .or(brand.rankType.eq(RankType.VIP_NORMAL).and(
-                    JPAExpressions.selectOne()
-                        .from(benefit)
-                        .where(benefit.brand.eq(brand)
-                            .and(benefit.rank.eq(Rank.VIP)))
-                        .exists()
-                ));
+                .or(brand.rankType.eq(RankType.VIP_NORMAL));
             case NORMAL -> brand.rankType.eq(RankType.NORMAL)
-                .or(brand.rankType.eq(RankType.VIP_NORMAL).and(
-                    JPAExpressions.selectOne()
-                        .from(benefit)
-                        .where(benefit.brand.eq(brand)
-                            .and(benefit.rank.eq(Rank.VIP)))
-                        .notExists()
-                ));
+                .or(brand.rankType.eq(RankType.VIP_NORMAL));
             case LOCAL -> brand.isLocal.isTrue();
         };
     }

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -2,11 +2,9 @@ package com.ureca.uble.domain.store.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ureca.uble.entity.Store;
 import com.ureca.uble.entity.enums.BenefitType;
-import com.ureca.uble.entity.enums.Rank;
 import com.ureca.uble.entity.enums.RankType;
 import com.ureca.uble.entity.enums.Season;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +13,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-import static com.ureca.uble.entity.QBenefit.benefit;
 import static com.ureca.uble.entity.QBrand.brand;
 import static com.ureca.uble.entity.QCategory.category;
 import static com.ureca.uble.entity.QStore.store;
@@ -44,21 +41,6 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
                 typeEq(type)
             )
             .fetch();
-    }
-
-    /**
-     * 매장에서 이용 가능한 혜택인지 판별
-     */
-    public Boolean checkStoreBenefitByType(Long storeId, BenefitType type) {
-        return jpaQueryFactory
-            .select(store.id)
-            .from(store)
-            .join(store.brand, brand)
-            .where(
-                store.id.eq(storeId),
-                getCondition(type)
-            )
-            .fetchFirst() != null;
     }
 
     public BooleanExpression getCondition(BenefitType type) {

--- a/src/main/java/com/ureca/uble/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/StoreRepository.java
@@ -11,4 +11,11 @@ public interface StoreRepository extends JpaRepository<Store, Long>, CustomStore
 
     @Query("SELECT s FROM Store s JOIN FETCH s.brand WHERE s.id = :storeId")
     Optional<Store> findByIdWithBrand(@Param("storeId") Long storeId);
+
+    @Query("SELECT s FROM Store s " +
+        "JOIN FETCH s.brand b " +
+        "JOIN FETCH b.category " +
+        "LEFT JOIN FETCH b.benefits " +
+        "WHERE s.id = :storeId")
+    Optional<Store> findByIdWithBrandAndCategoryAndBenefits(@Param("storeId") Long storeId);
 }

--- a/src/main/java/com/ureca/uble/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/StoreRepository.java
@@ -2,6 +2,13 @@ package com.ureca.uble.domain.store.repository;
 
 import com.ureca.uble.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long>, CustomStoreRepository {
+
+    @Query("SELECT s FROM Store s JOIN FETCH s.brand WHERE s.id = :storeId")
+    Optional<Store> findByIdWithBrand(@Param("storeId") Long storeId);
 }

--- a/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
+++ b/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
@@ -1,10 +1,14 @@
 package com.ureca.uble.domain.store.service;
 
+import com.ureca.uble.domain.store.dto.response.GetBenefitInfoRes;
+import com.ureca.uble.domain.store.dto.response.GetStoreDetailRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreRes;
 import com.ureca.uble.domain.store.repository.StoreRepository;
-import com.ureca.uble.entity.enums.BenefitType;
-import com.ureca.uble.entity.enums.Season;
+import com.ureca.uble.domain.users.repository.UsageCountRepository;
+import com.ureca.uble.domain.users.repository.UserRepository;
+import com.ureca.uble.entity.*;
+import com.ureca.uble.entity.enums.*;
 import com.ureca.uble.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
@@ -14,13 +18,18 @@ import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.ureca.uble.domain.store.exception.StoreErrorCode.OUT_OF_RANGE_INPUT;
+import static com.ureca.uble.domain.store.exception.StoreErrorCode.STORE_NOT_FOUND;
+import static com.ureca.uble.domain.users.exception.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class StoreService {
 
+    private final UserRepository userRepository;
+    private final UsageCountRepository usageCountRepository;
     private final StoreRepository storeRepository;
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
@@ -37,6 +46,36 @@ public class StoreService {
         return new GetStoreListRes(storeList);
     }
 
+    /**
+     * 매장 상세 정보 조회
+     */
+    public GetStoreDetailRes getStoreDetail(Double latitude, Double longitude, Long userId, Long storeId) {
+        User user = findUser(userId);
+        Store store = findByIdWithBrandAndCategoryAndBenefits(storeId);
+
+        // 좌표 기준 거리 계산
+        Double distance = calculateDistance(store.getLocation().getY(), store.getLocation().getX(), latitude, longitude);
+
+        // 혜택 사용 가능 여부 검증
+        RankType type = store.getBrand().getRankType();
+        boolean isNormalAvailable = (type == RankType.NORMAL || type == RankType.VIP_NORMAL) && handleNormalBenefit(user, store);
+        boolean isVipAvailable = (type == RankType.VIP || type == RankType.VIP_NORMAL) && handleVipBenefit(user);
+        boolean isLocalAvailable = (type == RankType.LOCAL) && handleLocalBenefit(user);
+
+        // 혜택 List 계산
+        List<GetBenefitInfoRes> benefitList = store.getBrand().getBenefits().stream()
+            .map(b -> GetBenefitInfoRes.of(b, getBenefitType(store.getBrand(), b)))
+            .toList();
+
+        return GetStoreDetailRes.of(store, distance, isNormalAvailable, isVipAvailable, isLocalAvailable, benefitList);
+    }
+
+    private BenefitType getBenefitType(Brand brand, Benefit benefit) {
+        return brand.getIsLocal() ? BenefitType.LOCAL :
+            benefit.getRank() == Rank.NONE ? BenefitType.VIP :
+                BenefitType.NORMAL;
+    }
+
     private void validateRange(double latitude, double longitude, int distance) {
         if ((latitude < -90 || latitude > 90) || (longitude < -180 || longitude > 180) || (distance <= 0 || distance > 10000)) {
             throw new GlobalException(OUT_OF_RANGE_INPUT);
@@ -45,5 +84,48 @@ public class StoreService {
 
     private Point getPoint(double latitude, double longitude) {
         return geometryFactory.createPoint(new Coordinate(longitude, latitude));
+    }
+
+    public static double calculateDistance(double latitude1, double longitude1, double latitude2, double longitude2) {
+        final int RADIUS = 6371000;
+
+        double dLat = Math.toRadians(latitude2 - latitude1);
+        double dLon = Math.toRadians(longitude2 - longitude1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+            + Math.cos(Math.toRadians(latitude1)) * Math.cos(Math.toRadians(latitude2))
+            * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return RADIUS * c;
+    }
+
+    private boolean handleVipBenefit(User user) {
+        return (user.getRank() == Rank.VIP || user.getRank() == Rank.VVIP) && user.getIsVipAvailable();
+    }
+
+    private boolean handleLocalBenefit(User user) {
+        return user.getRank() != Rank.NORMAL && user.getIsLocalAvailable();
+    }
+
+    private boolean handleNormalBenefit(User user, Store store) {
+        Benefit benefit = store.getBrand().getBenefits().stream()
+            .filter(b -> getBenefitType(store.getBrand(), b) != BenefitType.NORMAL)
+            .findFirst()
+            .orElse(null);
+
+        if (benefit == null) return false;
+
+        Optional<UsageCount> optionalCount = usageCountRepository.findByUserAndBenefit(user, benefit);
+
+        return optionalCount.map(uc -> benefit.getPeriod() == Period.NONE || benefit.getNumber() > uc.getCount()).orElse(true);
+    }
+
+    private Store findByIdWithBrandAndCategoryAndBenefits(Long storeId) {
+        return storeRepository.findByIdWithBrandAndCategoryAndBenefits(storeId).orElseThrow(() -> new GlobalException(STORE_NOT_FOUND));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
+++ b/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
@@ -86,7 +86,7 @@ public class StoreService {
         return geometryFactory.createPoint(new Coordinate(longitude, latitude));
     }
 
-    public static double calculateDistance(double latitude1, double longitude1, double latitude2, double longitude2) {
+    private static double calculateDistance(double latitude1, double longitude1, double latitude2, double longitude2) {
         final int RADIUS = 6371000;
 
         double dLat = Math.toRadians(latitude2 - latitude1);

--- a/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
+++ b/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
@@ -110,7 +110,7 @@ public class StoreService {
 
     private boolean handleNormalBenefit(User user, Store store) {
         Benefit benefit = store.getBrand().getBenefits().stream()
-            .filter(b -> getBenefitType(store.getBrand(), b) != BenefitType.NORMAL)
+            .filter(b -> getBenefitType(store.getBrand(), b) == BenefitType.NORMAL)
             .findFirst()
             .orElse(null);
 

--- a/src/main/java/com/ureca/uble/domain/users/service/UsageHistoryService.java
+++ b/src/main/java/com/ureca/uble/domain/users/service/UsageHistoryService.java
@@ -9,8 +9,10 @@ import com.ureca.uble.domain.users.repository.UsageCountRepository;
 import com.ureca.uble.domain.users.repository.UsageHistoryRepository;
 import com.ureca.uble.domain.users.repository.UserRepository;
 import com.ureca.uble.entity.*;
+import com.ureca.uble.entity.enums.BenefitType;
 import com.ureca.uble.entity.enums.Period;
 import com.ureca.uble.entity.enums.Rank;
+import com.ureca.uble.entity.enums.RankType;
 import com.ureca.uble.global.exception.GlobalException;
 import com.ureca.uble.global.response.CursorPageRes;
 import lombok.RequiredArgsConstructor;
@@ -49,10 +51,10 @@ public class UsageHistoryService {
 	public CreateUsageHistoryRes createUsageHistory(Long userId, Long storeId, CreateUsageHistoryReq req) {
 		// 정보 검증
 		User user = findUser(userId);
-		Store store = findStore(storeId);
+		Store store = findByIdWithBrand(storeId);
 
 		// store 검증
-		if(!storeRepository.checkStoreBenefitByType(storeId, req.getBenefitType())) {
+		if(!checkStoreBenefitByType(store, req.getBenefitType())) {
 			throw new GlobalException(BENEFIT_NOT_AVAILABLE);
 		}
 
@@ -102,6 +104,15 @@ public class UsageHistoryService {
 		}
 	}
 
+	private boolean checkStoreBenefitByType(Store store, BenefitType type) {
+		RankType rankType = store.getBrand().getRankType();
+		return switch (type) {
+			case VIP -> rankType == RankType.VIP || rankType == RankType.VIP_NORMAL;
+			case LOCAL -> rankType == RankType.LOCAL;
+			case NORMAL -> rankType == RankType.NORMAL || rankType == RankType.VIP_NORMAL;
+		};
+	}
+
 	private Benefit findBenefitByStoreId(Long storeId) {
 		return benefitRepository.findNormalBenefitByStoreId(storeId).orElseThrow(() -> new GlobalException(BENEFIT_NOT_FOUND));
 	}
@@ -110,7 +121,7 @@ public class UsageHistoryService {
 		return userRepository.findById(userId).orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
 	}
 
-	private Store findStore(Long storeId) {
-		return storeRepository.findById(storeId).orElseThrow(() -> new GlobalException(STORE_NOT_FOUND));
+	private Store findByIdWithBrand(Long storeId) {
+		return storeRepository.findByIdWithBrand(storeId).orElseThrow(() -> new GlobalException(STORE_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/ureca/uble/domain/users/service/UsageHistoryService.java
+++ b/src/main/java/com/ureca/uble/domain/users/service/UsageHistoryService.java
@@ -54,7 +54,7 @@ public class UsageHistoryService {
 		// store 검증
 		if(!storeRepository.checkStoreBenefitByType(storeId, req.getBenefitType())) {
 			throw new GlobalException(BENEFIT_NOT_AVAILABLE);
-		};
+		}
 
 		// 등급에 따른 추가 작업 처리
 		switch (req.getBenefitType()) {

--- a/src/main/java/com/ureca/uble/entity/enums/Rank.java
+++ b/src/main/java/com/ureca/uble/entity/enums/Rank.java
@@ -9,7 +9,8 @@ public enum Rank {
     NORMAL("일반"),
     PREMIUM("우수"),
     VIP("VIP"),
-    VVIP("VVIP");
+    VVIP("VVIP"),
+    NONE("VIP콕");
 
     private final String name;
 }

--- a/src/test/java/com/ureca/uble/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/store/service/StoreServiceTest.java
@@ -1,11 +1,13 @@
 package com.ureca.uble.domain.store.service;
 
+import com.ureca.uble.domain.brand.repository.BenefitRepository;
+import com.ureca.uble.domain.store.dto.response.GetStoreDetailRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
 import com.ureca.uble.domain.store.repository.StoreRepository;
-import com.ureca.uble.entity.Brand;
-import com.ureca.uble.entity.Category;
-import com.ureca.uble.entity.Store;
+import com.ureca.uble.domain.users.repository.UserRepository;
+import com.ureca.uble.entity.*;
 import com.ureca.uble.entity.enums.BenefitType;
+import com.ureca.uble.entity.enums.RankType;
 import com.ureca.uble.entity.enums.Season;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +21,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,6 +39,9 @@ class StoreServiceTest {
 
     @InjectMocks
     private StoreService storeService;
+
+    @Mock
+    private UserRepository userRepository;
 
     @Test
     @DisplayName("반경 500m 내의 매장 중 필터링 조건에 맞는 매장 리스트를 조회한다.")
@@ -73,5 +80,68 @@ class StoreServiceTest {
         assertNotNull(result);
         assertEquals(1, result.getStoreList().size());
         assertEquals("테스트 선릉점", result.getStoreList().get(0).getStoreName());
+    }
+
+    @Test
+    @DisplayName("매장 상세 정보를 조회한다.")
+    void getStoreDetailSuccess() {
+        // given
+        Double latitude = 37.5;
+        Double longitude = 127.0;
+        Long userId = 1L;
+        Long storeId = 10L;
+
+        // Mock 객체 생성 및 세팅
+        User mockUser = mock(User.class);
+        Brand mockBrand = mock(Brand.class);
+        Category mockCategory = mock(Category.class);
+        Store mockStore = mock(Store.class);
+        Point mockLocation = mock(Point.class);
+        Benefit mockBenefit = mock(Benefit.class);
+
+        when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(mockUser));
+        when(storeRepository.findByIdWithBrandAndCategoryAndBenefits(storeId)).thenReturn(Optional.of(mockStore));
+
+        when(mockStore.getBrand()).thenReturn(mockBrand);
+        when(mockStore.getId()).thenReturn(storeId);
+        when(mockStore.getName()).thenReturn("스타벅스 선릉점");
+        when(mockStore.getAddress()).thenReturn("서울 강남구 테헤란로64길 18");
+        when(mockStore.getPhoneNumber()).thenReturn("02-1234-5678");
+        when(mockStore.getLocation()).thenReturn(mockLocation);
+
+        when(mockLocation.getY()).thenReturn(37.0);
+        when(mockLocation.getX()).thenReturn(127.0);
+
+        when(mockBrand.getId()).thenReturn(123L);
+        when(mockBrand.getDescription()).thenReturn("커피가 맛있는 스타벅스");
+        when(mockBrand.getImageUrl()).thenReturn("https://example.com");
+        when(mockBrand.getCategory()).thenReturn(mockCategory);
+        when(mockCategory.getName()).thenReturn("음식점");
+        when(mockBrand.getRankType()).thenReturn(RankType.NORMAL);
+
+        when(mockBrand.getBenefits()).thenReturn(List.of(mockBenefit));
+        when(mockBenefit.getId()).thenReturn(1001L);
+        when(mockBenefit.getRank()).thenReturn(com.ureca.uble.entity.enums.Rank.NORMAL);
+        when(mockBenefit.getContent()).thenReturn("아메리카노 무료");
+        when(mockBenefit.getManual()).thenReturn("매장 방문 시 쿠폰 제시");
+        when(mockBenefit.getPeriod()).thenReturn(com.ureca.uble.entity.enums.Period.MONTHLY);
+        when(mockBenefit.getNumber()).thenReturn(1);
+
+        // when
+        GetStoreDetailRes result = storeService.getStoreDetail(latitude, longitude, userId, storeId);
+
+        // then
+        assertThat(result.getBrandId()).isEqualTo(123L);
+        assertThat(result.getStoreId()).isEqualTo(storeId);
+        assertThat(result.getStoreName()).isEqualTo("스타벅스 선릉점");
+        assertThat(result.getDescription()).isEqualTo("커피가 맛있는 스타벅스");
+        assertThat(result.getAddress()).isEqualTo("서울 강남구 테헤란로64길 18");
+        assertThat(result.getPhoneNumber()).isEqualTo("02-1234-5678");
+        assertThat(result.getCategory()).isEqualTo("음식점");
+        assertThat(result.getImageUrl()).isEqualTo("https://example.com");
+        assertThat(result.getBenefitList()).hasSize(1);
+        assertThat(result.getBenefitList().get(0).getBenefitId()).isEqualTo(1001L);
+        assertThat(result.getBenefitList().get(0).getType()).isEqualTo("NORMAL");
+        assertThat(result.getBenefitList().get(0).getContent()).isEqualTo("아메리카노 무료");
     }
 }

--- a/src/test/java/com/ureca/uble/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/store/service/StoreServiceTest.java
@@ -4,6 +4,7 @@ import com.ureca.uble.domain.brand.repository.BenefitRepository;
 import com.ureca.uble.domain.store.dto.response.GetStoreDetailRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
 import com.ureca.uble.domain.store.repository.StoreRepository;
+import com.ureca.uble.domain.users.repository.UsageCountRepository;
 import com.ureca.uble.domain.users.repository.UserRepository;
 import com.ureca.uble.entity.*;
 import com.ureca.uble.entity.enums.BenefitType;
@@ -42,6 +43,9 @@ class StoreServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private UsageCountRepository usageCountRepository;
 
     @Test
     @DisplayName("반경 500m 내의 매장 중 필터링 조건에 맞는 매장 리스트를 조회한다.")
@@ -91,7 +95,6 @@ class StoreServiceTest {
         Long userId = 1L;
         Long storeId = 10L;
 
-        // Mock 객체 생성 및 세팅
         User mockUser = mock(User.class);
         Brand mockBrand = mock(Brand.class);
         Category mockCategory = mock(Category.class);
@@ -99,8 +102,9 @@ class StoreServiceTest {
         Point mockLocation = mock(Point.class);
         Benefit mockBenefit = mock(Benefit.class);
 
-        when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(mockUser));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(storeRepository.findByIdWithBrandAndCategoryAndBenefits(storeId)).thenReturn(Optional.of(mockStore));
+        when(usageCountRepository.findByUserAndBenefit(any(), any())).thenReturn(Optional.empty());
 
         when(mockStore.getBrand()).thenReturn(mockBrand);
         when(mockStore.getId()).thenReturn(storeId);
@@ -108,10 +112,8 @@ class StoreServiceTest {
         when(mockStore.getAddress()).thenReturn("서울 강남구 테헤란로64길 18");
         when(mockStore.getPhoneNumber()).thenReturn("02-1234-5678");
         when(mockStore.getLocation()).thenReturn(mockLocation);
-
         when(mockLocation.getY()).thenReturn(37.0);
         when(mockLocation.getX()).thenReturn(127.0);
-
         when(mockBrand.getId()).thenReturn(123L);
         when(mockBrand.getDescription()).thenReturn("커피가 맛있는 스타벅스");
         when(mockBrand.getImageUrl()).thenReturn("https://example.com");

--- a/src/test/java/com/ureca/uble/domain/users/service/UsageHistoryServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/users/service/UsageHistoryServiceTest.java
@@ -10,11 +10,10 @@ import com.ureca.uble.domain.users.repository.UsageHistoryRepository;
 import com.ureca.uble.domain.users.repository.UserRepository;
 import com.ureca.uble.entity.*;
 import com.ureca.uble.entity.enums.BenefitType;
-import com.ureca.uble.entity.enums.Period;
 import com.ureca.uble.entity.enums.Rank;
+import com.ureca.uble.entity.enums.RankType;
 import com.ureca.uble.global.exception.GlobalException;
 import com.ureca.uble.global.response.CursorPageRes;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,16 +79,18 @@ public class UsageHistoryServiceTest {
 		Long storeId = 100L;
 
 		User vipUser = mock(User.class);
-		Store store = mock(Store.class);
+		Store mockStore = mock(Store.class);
+		Brand mockBrand = mock(Brand.class);
 		when(vipUser.getRank()).thenReturn(Rank.VIP);
+		when(mockStore.getBrand()).thenReturn(mockBrand);
 		when(vipUser.getIsVipAvailable()).thenReturn(true);
+		when(mockBrand.getRankType()).thenReturn(RankType.VIP);
 		when(userRepository.findById(userId)).thenReturn(Optional.of(vipUser));
-		when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+		when(storeRepository.findByIdWithBrand(storeId)).thenReturn(Optional.of(mockStore));
 
 		UsageHistory savedHistory = mock(UsageHistory.class);
 		when(savedHistory.getId()).thenReturn(10L);
 		when(usageHistoryRepository.save(any())).thenReturn(savedHistory);
-		when(storeRepository.checkStoreBenefitByType(eq(storeId), any())).thenReturn(true);
 
 		// when
 		CreateUsageHistoryRes res = usageHistoryService.createUsageHistory(userId, storeId, new CreateUsageHistoryReq(BenefitType.VIP));
@@ -108,12 +109,13 @@ public class UsageHistoryServiceTest {
 		Long storeId = 100L;
 
 		User vipUser = mock(User.class);
-		Store store = mock(Store.class);
+		Store mockStore = mock(Store.class);
+		Brand mockBrand = mock(Brand.class);
 		when(vipUser.getRank()).thenReturn(Rank.VIP);
-		when(vipUser.getIsVipAvailable()).thenReturn(false);
+		when(mockStore.getBrand()).thenReturn(mockBrand);
+		when(mockBrand.getRankType()).thenReturn(RankType.VIP);
 		when(userRepository.findById(userId)).thenReturn(Optional.of(vipUser));
-		when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
-		when(storeRepository.checkStoreBenefitByType(eq(storeId), any())).thenReturn(true);
+		when(storeRepository.findByIdWithBrand(storeId)).thenReturn(Optional.of(mockStore));
 
 		// when
 		GlobalException exception = assertThrows(GlobalException.class, () -> {
@@ -134,16 +136,19 @@ public class UsageHistoryServiceTest {
 		Long storeId = 100L;
 
 		User localUser = mock(User.class);
-		Store store = mock(Store.class);
-		when(localUser.getRank()).thenReturn(Rank.PREMIUM);
+		Store mockStore = mock(Store.class);
+		Brand mockBrand = mock(Brand.class);
+
+		when(localUser.getRank()).thenReturn(Rank.VIP);
 		when(localUser.getIsLocalAvailable()).thenReturn(true);
+		when(mockStore.getBrand()).thenReturn(mockBrand);
+		when(mockBrand.getRankType()).thenReturn(RankType.LOCAL);
 		when(userRepository.findById(userId)).thenReturn(Optional.of(localUser));
-		when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+		when(storeRepository.findByIdWithBrand(storeId)).thenReturn(Optional.of(mockStore));
 
 		UsageHistory savedHistory = mock(UsageHistory.class);
 		when(savedHistory.getId()).thenReturn(10L);
 		when(usageHistoryRepository.save(any())).thenReturn(savedHistory);
-		when(storeRepository.checkStoreBenefitByType(eq(storeId), any())).thenReturn(true);
 
 		// when
 		CreateUsageHistoryRes res = usageHistoryService.createUsageHistory(userId, storeId, new CreateUsageHistoryReq(BenefitType.LOCAL));
@@ -161,12 +166,12 @@ public class UsageHistoryServiceTest {
 		Long storeId = 100L;
 
 		User localUser = mock(User.class);
-		Store store = mock(Store.class);
-		when(localUser.getRank()).thenReturn(Rank.PREMIUM);
-		when(localUser.getIsLocalAvailable()).thenReturn(false);
+		Store mockStore = mock(Store.class);
+		Brand mockBrand = mock(Brand.class);
+		when(mockStore.getBrand()).thenReturn(mockBrand);
+		when(mockBrand.getRankType()).thenReturn(RankType.LOCAL);
 		when(userRepository.findById(userId)).thenReturn(Optional.of(localUser));
-		when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
-		when(storeRepository.checkStoreBenefitByType(eq(storeId), any())).thenReturn(true);
+		when(storeRepository.findByIdWithBrand(storeId)).thenReturn(Optional.of(mockStore));
 
 		// when
 		GlobalException exception = assertThrows(GlobalException.class, () ->
@@ -187,9 +192,12 @@ public class UsageHistoryServiceTest {
 		Long storeId = 100L;
 
 		User normalUser = mock(User.class);
-		Store store = mock(Store.class);
+		Store mockStore = mock(Store.class);
+		Brand mockBrand = mock(Brand.class);
+		when(mockStore.getBrand()).thenReturn(mockBrand);
+		when(mockBrand.getRankType()).thenReturn(RankType.NORMAL);
 		when(userRepository.findById(userId)).thenReturn(Optional.of(normalUser));
-		when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+		when(storeRepository.findByIdWithBrand(storeId)).thenReturn(Optional.of(mockStore));
 
 		Benefit benefit = mock(Benefit.class);
 		when(benefit.getNumber()).thenReturn(3);
@@ -199,7 +207,6 @@ public class UsageHistoryServiceTest {
 		UsageHistory savedHistory = mock(UsageHistory.class);
 		when(savedHistory.getId()).thenReturn(10L);
 		when(usageHistoryRepository.save(any())).thenReturn(savedHistory);
-		when(storeRepository.checkStoreBenefitByType(eq(storeId), any())).thenReturn(true);
 
 		// when
 		CreateUsageHistoryRes res = usageHistoryService.createUsageHistory(userId, storeId, new CreateUsageHistoryReq(BenefitType.NORMAL));
@@ -218,19 +225,21 @@ public class UsageHistoryServiceTest {
 		Long storeId = 100L;
 
 		User normalUser = mock(User.class);
-		Store store = mock(Store.class);
+		Store mockStore = mock(Store.class);
+		Brand mockBrand = mock(Brand.class);
+
+		when(mockStore.getBrand()).thenReturn(mockBrand);
+		when(mockBrand.getRankType()).thenReturn(RankType.NORMAL);
 		when(userRepository.findById(userId)).thenReturn(Optional.of(normalUser));
-		when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+		when(storeRepository.findByIdWithBrand(storeId)).thenReturn(Optional.of(mockStore));
 
 		Benefit benefit = mock(Benefit.class);
 		when(benefit.getNumber()).thenReturn(2);
-		when(benefit.getPeriod()).thenReturn(Period.MONTHLY);
 		when(benefitRepository.findNormalBenefitByStoreId(storeId)).thenReturn(Optional.of(benefit));
 
 		UsageCount usageCount = mock(UsageCount.class);
 		when(usageCount.getCount()).thenReturn(2);
 		when(usageCountRepository.findByUserAndBenefit(normalUser, benefit)).thenReturn(Optional.of(usageCount));
-		when(storeRepository.checkStoreBenefitByType(eq(storeId), any())).thenReturn(true);
 
 		// when
 		GlobalException exception = assertThrows(GlobalException.class, () ->
@@ -252,10 +261,11 @@ public class UsageHistoryServiceTest {
 
 		User mockUser = mock(User.class);
 		Store mockStore = mock(Store.class);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-		when(storeRepository.findById(storeId)).thenReturn(Optional.of(mockStore));
+		Brand mockBrand = mock(Brand.class);
 
-		when(storeRepository.checkStoreBenefitByType(eq(storeId), any())).thenReturn(false);
+		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+		when(storeRepository.findByIdWithBrand(storeId)).thenReturn(Optional.of(mockStore));
+		when(mockStore.getBrand()).thenReturn(mockBrand);
 
 		// when
 		GlobalException exception = assertThrows(GlobalException.class, () ->


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 

## 📝작업 내용

- 매장 상세 조회 API를 구현하였습니다.
- 매장 이용 내역 조회/추가 시 검증 로직을 수정하였습니다.
- storeId를 통해 Store 객체를 불러올 때 N+1 문제를 방지하기 위해 fetch join을 사용하도록 수정하였습니다.

## 📷스크린샷 (선택)


## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매장 상세 정보를 조회할 수 있는 엔드포인트가 추가되었습니다. 사용자의 위치와 혜택 이용 가능 여부, 상세 혜택 목록, 거리 등 다양한 정보를 확인할 수 있습니다.

* **버그 수정**
  * 불필요한 혜택 관련 메서드와 인터페이스가 정리되었습니다.

* **리팩터**
  * 혜택 유형 및 랭크 처리 로직이 간소화되고, 관련 코드가 개선되었습니다.

* **테스트**
  * 매장 상세 정보 조회 기능에 대한 단위 테스트가 추가되었습니다.
  * 기존 혜택 관련 테스트가 도메인 모델 변경에 맞게 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->