### PR TITLE
[Fix] exposedHeaders 설정 및 cors 설정

### DIFF
--- a/src/main/java/com/ureca/uble/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/uble/global/config/SecurityConfig.java
@@ -61,11 +61,16 @@ public class SecurityConfig {
 			"http://localhost:3001",
 			"http://localhost:3002",
 			"http://localhost:3003",
+			"https://localhost:3000",
+			"https://localhost:3001",
+			"https://localhost:3002",
+			"https://localhost:3003",
 			domainBaseUrl
 		));
 		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
 		configuration.setAllowCredentials(true);
 		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setExposedHeaders(List.of("Authorization", "Content-Type"));
 		configuration.setMaxAge(3600L);
 
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없습니다

## 📝작업 내용

> setExposedHeaders에 Authorization 추가하고 cors 설정을 변경했습니다. 

## 📷스크린샷 (선택)

> 
## 💬리뷰 요구사항(선택)

> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * CORS 설정이 업데이트되어 HTTPS를 사용하는 localhost(포트 3000~3003)도 허용됩니다.
  * 클라이언트에서 "Authorization" 및 "Content-Type" 헤더에 접근할 수 있도록 노출 범위가 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->