### PR TITLE
[Fix] 사용자 정보 관련 API들에 바코드 번호 추가

### DIFF
--- a/src/main/java/com/ureca/uble/domain/users/dto/request/UpdateUserInfoReq.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/request/UpdateUserInfoReq.java
@@ -22,6 +22,9 @@ public class UpdateUserInfoReq {
 	@Schema(description = "생년월일", example = "2001.01.01")
 	private LocalDate birthDate;
 
+	@Schema(description = "바코드 번호", example = "123456787654321")
+	private String barcode;
+
 	@Schema(description = "카테고리 ID 리스트", example = "[1, 3, 5]")
 	private List<Long> categoryIds;
 }

--- a/src/main/java/com/ureca/uble/domain/users/dto/response/GetUserInfoRes.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/response/GetUserInfoRes.java
@@ -29,6 +29,9 @@ public class GetUserInfoRes {
 	@Schema(description = "생년월일", example = "2001.01.01")
 	private LocalDate birthDate;
 
+	@Schema(description = "바코드 번호", example = "123456787654321")
+	private String barcode;
+
 	@Schema(description = "카테고리 ID 리스트", example = "[1, 3, 5]")
 	private List<Long> categoryIds;
 
@@ -39,6 +42,7 @@ public class GetUserInfoRes {
 			.rank(user.getRank())
 			.gender(user.getGender())
 			.birthDate(user.getBirthDate())
+			.barcode(user.getBarcode())
 			.categoryIds(safeCategories)
 			.build();
 	}

--- a/src/main/java/com/ureca/uble/domain/users/dto/response/UpdateUserInfoRes.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/response/UpdateUserInfoRes.java
@@ -26,6 +26,9 @@ public class UpdateUserInfoRes {
 	@Schema(description = "생년월일", example = "2001.01.01")
 	private LocalDate birthDate;
 
+	@Schema(description = "바코드 번호", example = "123456787654321")
+	private String barcode;
+
 	@Schema(description = "카테고리 ID 리스트", example = "[1, 3, 5]")
 	private List<Long> categoryIds;
 
@@ -35,6 +38,7 @@ public class UpdateUserInfoRes {
 			.rank(user.getRank())
 			.gender(user.getGender())
 			.birthDate(user.getBirthDate())
+			.barcode(user.getBarcode())
 			.categoryIds(safeCategories)
 			.build();
 	}

--- a/src/main/java/com/ureca/uble/domain/users/service/UserService.java
+++ b/src/main/java/com/ureca/uble/domain/users/service/UserService.java
@@ -45,7 +45,8 @@ public class UserService {
 		user.updateUserInfo(
 			request.getRank(),
 			request.getGender(),
-			request.getBirthDate()
+			request.getBirthDate(),
+			request.getBarcode()
 		);
 
 		userCategoryRepository.deleteByUser(user);

--- a/src/main/java/com/ureca/uble/entity/User.java
+++ b/src/main/java/com/ureca/uble/entity/User.java
@@ -53,9 +53,12 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    @Column
+    private String barcode;
+
     @Builder(access = PRIVATE)
     private User(String nickname, Rank rank, Role role, String providerId, Boolean isVipAvailable,
-                 Boolean isLocalAvailable, Boolean isDeleted, LocalDate birthDate, Gender gender) {
+                 Boolean isLocalAvailable, Boolean isDeleted, LocalDate birthDate, Gender gender, String barcode) {
         this.nickname = nickname;
         this.rank = rank;
         this.role = role;
@@ -65,6 +68,7 @@ public class User extends BaseEntity {
         this.isDeleted = isDeleted;
         this.birthDate = birthDate;
         this.gender = gender;
+        this.barcode = barcode;
     }
 
     public static User createTmpUser(String kakaoId, String nickname){
@@ -74,10 +78,11 @@ public class User extends BaseEntity {
             .rank(Rank.NORMAL)
             .role(Role.TMP_USER)
             .isDeleted(false)
-            .isVipAvailable(false)
-            .isLocalAvailable(false)
+            .isVipAvailable(true)
+            .isLocalAvailable(true)
             .birthDate(null)
             .gender(null)
+            .barcode(null)
             .build();
     }
 
@@ -89,10 +94,11 @@ public class User extends BaseEntity {
         this.isLocalAvailable = isLocalAvailable;
     }
 
-    public void updateUserInfo(Rank rank, Gender gender, LocalDate birthDate) {
+    public void updateUserInfo(Rank rank, Gender gender, LocalDate birthDate, String barcode) {
         this.rank = rank;
         this.gender = gender;
         this.birthDate = birthDate;
+        this.barcode = barcode;
 
         if(this.role == Role.TMP_USER){
             this.role = Role.USER;

--- a/src/test/java/com/ureca/uble/domain/users/service/UserServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/users/service/UserServiceTest.java
@@ -98,6 +98,7 @@ public class UserServiceTest {
 		when(request.getRank()).thenReturn(Rank.VIP);
 		when(request.getGender()).thenReturn(Gender.FEMALE);
 		when(request.getBirthDate()).thenReturn(LocalDate.of(1999, 1, 1));
+		when(request.getBarcode()).thenReturn("123456787654321");
 		when(request.getCategoryIds()).thenReturn(categoryIds);
 
 		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
@@ -107,7 +108,7 @@ public class UserServiceTest {
 		UpdateUserInfoRes result = userService.updateUserInfo(userId, request);
 
 		//then
-		verify(user).updateUserInfo(Rank.VIP, Gender.FEMALE, LocalDate.of(1999, 1, 1));
+		verify(user).updateUserInfo(Rank.VIP, Gender.FEMALE, LocalDate.of(1999, 1, 1), "123456787654321");
 		verify(userCategoryRepository).deleteByUser(user);
 		verify(userCategoryRepository, times(2)).save(any(UserCategory.class));
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #61 

## 📝작업 내용

> User 엔티티에 barcode 컬럼 추가했습니다. 
> 사용자 정보 조회 API와 사용자 정보 등록/수정 API에 barcode 관련 코드 추가하였습니다.
> UserServiceTest 수정하였습니다.
> 최초 가입시 is_local_available과 is_vip_available이 false로 초기화되던 것을 true로 초기화되도록 수정하였습니다. 


## 📷스크린샷 (선택)

> 

## 💬리뷰 요구사항(선택)

> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 정보에 바코드 번호를 추가하여 입력 및 조회가 가능해졌습니다.

* **버그 수정**
  * 사용자 정보 수정 및 조회 시 바코드 정보가 정상적으로 반영되도록 개선되었습니다.

* **테스트**
  * 바코드 필드에 대한 테스트가 추가되어 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->