### PR TITLE
[UBLE-14] feat: 지도 초기 데이터 조회 기능 추가 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/ureca/uble/domain/brand/controller/BrandController.java
+++ b/src/main/java/com/ureca/uble/domain/brand/controller/BrandController.java
@@ -2,6 +2,7 @@ package com.ureca.uble.domain.brand.controller;
 
 import com.ureca.uble.domain.brand.dto.response.BrandDetailRes;
 import com.ureca.uble.domain.brand.dto.response.BrandListRes;
+import com.ureca.uble.domain.brand.dto.response.InitialDataRes;
 import com.ureca.uble.domain.brand.dto.response.SearchBrandListRes;
 import com.ureca.uble.domain.brand.service.BrandService;
 import com.ureca.uble.entity.enums.BenefitType;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -69,5 +71,13 @@ public class BrandController {
 		@Parameter(description = "한 번에 가져올 크기")
 		@RequestParam(defaultValue = "5") int size){
 		return CommonResponse.success(brandService.getBrandListBySearch(userId, keyword, category, season, type, page, size));
+	}
+
+	@Operation(summary = "지도 초기 데이터 조회")
+	@GetMapping("/map/initial-data")
+	public CommonResponse<InitialDataRes> getInitialData(
+		@Parameter(description = "사용자정보", required = true)
+		@AuthenticationPrincipal Long userId) {
+		return CommonResponse.success(brandService.getInitialData(userId));
 	}
 }

--- a/src/main/java/com/ureca/uble/domain/brand/dto/response/CategoryRes.java
+++ b/src/main/java/com/ureca/uble/domain/brand/dto/response/CategoryRes.java
@@ -1,0 +1,26 @@
+package com.ureca.uble.domain.brand.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "카테고리 정보 DTO")
+public class CategoryRes {
+    @Schema(description = "카테고리 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "카테고리 이름", example = "액티비티")
+    private String name;
+
+    public static CategoryRes of(Long id, String name) {
+        return CategoryRes.builder()
+                .id(id)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/brand/dto/response/InitialDataRes.java
+++ b/src/main/java/com/ureca/uble/domain/brand/dto/response/InitialDataRes.java
@@ -1,0 +1,25 @@
+package com.ureca.uble.domain.brand.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "지도 초기 데이터 조회 응답 DTO")
+public class InitialDataRes {
+    @Schema(description = "필터용 카테고리 리스트", required = true)
+    private List<CategoryRes> categories;
+
+    @Schema(description = "사용자 저장 위치 리스트", required = true)
+    private List<LocationRes> locations;
+
+    public static InitialDataRes of(List<CategoryRes> categories, List<LocationRes> locations) {
+        return InitialDataRes.builder()
+                .categories(categories)
+                .locations(locations)
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/brand/dto/response/LocationRes.java
+++ b/src/main/java/com/ureca/uble/domain/brand/dto/response/LocationRes.java
@@ -1,0 +1,31 @@
+package com.ureca.uble.domain.brand.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "저장 위치 정보 DTO")
+public class LocationRes {
+    @Schema(description = "저장 위치 ID", example = "10")
+    private Long id;
+
+    @Schema(description = "저장 위치 명칭", example = "집")
+    private String name;
+
+    @Schema(description = "경도(longitude)", example = "127.027644")
+    private double longitude;
+
+    @Schema(description = "위도(latitude)", example = "37.497943")
+    private double latitude;
+
+    public static LocationRes of(Long id, String name, double longitude, double latitude) {
+        return LocationRes.builder()
+                .id(id)
+                .name(name)
+                .longitude(longitude)
+                .latitude(latitude)
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/brand/repository/MapCategoryRepository.java
+++ b/src/main/java/com/ureca/uble/domain/brand/repository/MapCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.ureca.uble.domain.brand.repository;
+
+import com.ureca.uble.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MapCategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findByOrderByIdAsc();
+}

--- a/src/main/java/com/ureca/uble/domain/brand/repository/MapPinRepository.java
+++ b/src/main/java/com/ureca/uble/domain/brand/repository/MapPinRepository.java
@@ -1,0 +1,10 @@
+package com.ureca.uble.domain.brand.repository;
+
+import com.ureca.uble.entity.Pin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MapPinRepository extends JpaRepository<Pin, Long> {
+    List<Pin> findByUserIdOrderByIdAsc(Long userId);
+}

--- a/src/main/java/com/ureca/uble/domain/brand/service/BrandService.java
+++ b/src/main/java/com/ureca/uble/domain/brand/service/BrandService.java
@@ -1,14 +1,9 @@
 package com.ureca.uble.domain.brand.service;
 
 import com.ureca.uble.domain.bookmark.repository.BookmarkRepository;
-import com.ureca.uble.domain.brand.dto.response.BenefitDetailRes;
-import com.ureca.uble.domain.brand.dto.response.BrandDetailRes;
-import com.ureca.uble.domain.brand.dto.response.BrandListRes;
-import com.ureca.uble.domain.brand.dto.response.SearchBrandListRes;
+import com.ureca.uble.domain.brand.dto.response.*;
 import com.ureca.uble.domain.brand.exception.BrandErrorCode;
-import com.ureca.uble.domain.brand.repository.BrandClickLogDocumentRepository;
-import com.ureca.uble.domain.brand.repository.BrandNoriDocumentRepository;
-import com.ureca.uble.domain.brand.repository.BrandRepository;
+import com.ureca.uble.domain.brand.repository.*;
 import com.ureca.uble.domain.common.dto.response.CursorPageRes;
 import com.ureca.uble.domain.store.repository.SearchLogDocumentRepository;
 import com.ureca.uble.domain.users.repository.UserRepository;
@@ -45,6 +40,8 @@ public class BrandService {
 	private final BrandClickLogDocumentRepository brandClickLogDocumentRepository;
 	private final UserRepository userRepository;
 	private final SearchLogDocumentRepository searchLogDocumentRepository;
+	private final MapCategoryRepository mapCategoryRepository;
+	private final MapPinRepository mapPinRepository;
 
 	/**
 	 * 제휴처 상세 조회
@@ -161,6 +158,25 @@ public class BrandService {
 		}
 
 		return SearchBrandListRes.of(brandList, totalCnt, totalPage);
+	}
+
+	/**
+	 * 지도 초기 데이터 조회
+	 */
+	public InitialDataRes getInitialData(Long userId) {
+		User user = findUser(userId);
+		List<CategoryRes> categories = mapCategoryRepository.findByOrderByIdAsc() .stream()
+				.map(category -> CategoryRes.of(category.getId(), category.getName()))
+				.collect(Collectors.toList());
+
+		List<LocationRes> locations = mapPinRepository.findByUserIdOrderByIdAsc(userId).stream()
+				.map(pin -> LocationRes.of(
+						pin.getId(), pin.getName(),
+						pin.getLocation().getX(), pin.getLocation().getY()
+				))
+				.collect(Collectors.toList());
+
+		return InitialDataRes.builder().categories(categories).locations(locations).build();
 	}
 
 	private User findUser(Long userId) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #16 

## 📝작업 내용

- FE의 요청으로 지도 초기 데이터 조회 기능을 구현하였습니다.
- 카테고리(id, name) 리스트와 저장 위치(id, name, longitude, latitude) 리스트를 반환합니다.
- MapCategoryRepository와 MapPinRepository에 ID 오름차순 조회 메소드를 추가하였습니다.
- 테스트 코드 작성

## 📷스크린샷 (선택)
<img width="1457" height="798" alt="스크린샷 2025-07-21 오전 1 09 43" src="https://github.com/user-attachments/assets/f8ad9c41-bc19-48a2-9ec8-ec47f3103430" />

<img width="1467" height="770" alt="스크린샷 2025-07-21 오전 1 10 13" src="https://github.com/user-attachments/assets/dd8dfdaa-e5bf-402a-ab4a-0e70c5bdfda0" />


## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 지도 초기 데이터(카테고리 및 저장 위치 목록)를 조회하는 새로운 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 해당 없음

* **테스트**
  * 지도 초기 데이터 조회 기능에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->