### PR TITLE
[Feat] 사용자 개인 통계 조회 API 구현

### DIFF
--- a/src/main/java/com/ureca/uble/domain/brand/repository/BrandClickLogDocumentRepository.java
+++ b/src/main/java/com/ureca/uble/domain/brand/repository/BrandClickLogDocumentRepository.java
@@ -3,5 +3,5 @@ package com.ureca.uble.domain.brand.repository;
 import com.ureca.uble.entity.document.BrandClickLogDocument;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface BrandClickLogDocumentRepository extends ElasticsearchRepository<BrandClickLogDocument, String> {
+public interface BrandClickLogDocumentRepository extends ElasticsearchRepository<BrandClickLogDocument, String>, CustomBrandClickLogDocumentRepository {
 }

--- a/src/main/java/com/ureca/uble/domain/brand/repository/CustomBrandClickLogDocumentRepository.java
+++ b/src/main/java/com/ureca/uble/domain/brand/repository/CustomBrandClickLogDocumentRepository.java
@@ -1,0 +1,7 @@
+package com.ureca.uble.domain.brand.repository;
+
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+
+public interface CustomBrandClickLogDocumentRepository {
+    ElasticsearchAggregations getCategoryAndBrandRankByUserId(Long userId);
+}

--- a/src/main/java/com/ureca/uble/domain/brand/repository/CustomBrandClickLogDocumentRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/brand/repository/CustomBrandClickLogDocumentRepositoryImpl.java
@@ -1,0 +1,59 @@
+package com.ureca.uble.domain.brand.repository;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.util.NamedValue;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomBrandClickLogDocumentRepositoryImpl implements CustomBrandClickLogDocumentRepository {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Override
+    public ElasticsearchAggregations getCategoryAndBrandRankByUserId(Long userId) {
+        // 카테고리 순위
+        Aggregation categoryAggregation = Aggregation.of(a -> a
+            .terms(t -> t
+                .field("category")
+                .order(List.of(NamedValue.of("_count", SortOrder.Desc)))
+            )
+        );
+
+        // 제휴처 순위
+        Aggregation brandAggregation = Aggregation.of(a -> a
+            .terms(t -> t
+                .field("brandName")
+                .size(10)
+                .order(List.of(NamedValue.of("_count", SortOrder.Desc)))
+            )
+        );
+
+        // Query 생성
+        NativeQuery query = NativeQuery.builder()
+            .withQuery(q -> q
+                .term(t -> t
+                    .field("userId")
+                    .value(userId)
+                )
+            )
+            .withAggregation("category_rank", categoryAggregation)
+            .withAggregation("brand_rank", brandAggregation)
+            .withMaxResults(0)
+            .build();
+
+        // 실행 및 결과 반환
+        return (ElasticsearchAggregations) elasticsearchOperations
+            .search(query, Map.class, IndexCoordinates.of("brand-click-log", "store-click-log"))
+            .getAggregations();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/users/controller/UserController.java
+++ b/src/main/java/com/ureca/uble/domain/users/controller/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
 	 *
 	 * @param userId 사용자 정보
 	 */
-	@Operation(summary = "사용자 통계 정보 조회", description = "마이페이지에 표시될 사용자 정보를 조회합니다.")
+	@Operation(summary = "사용자 통계 정보 조회", description = "사용자의 개인 통계 데이터를 조회합니다.")
 	@GetMapping("/statistics")
 	public CommonResponse<GetUserStatisticsRes> getUserStatistics(
 		@Parameter(description = "사용자정보", required = true)

--- a/src/main/java/com/ureca/uble/domain/users/controller/UserController.java
+++ b/src/main/java/com/ureca/uble/domain/users/controller/UserController.java
@@ -1,23 +1,17 @@
 package com.ureca.uble.domain.users.controller;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.ureca.uble.domain.common.dto.response.CommonResponse;
 import com.ureca.uble.domain.users.dto.request.UpdateUserInfoReq;
 import com.ureca.uble.domain.users.dto.response.GetRecommendationListRes;
 import com.ureca.uble.domain.users.dto.response.GetUserInfoRes;
+import com.ureca.uble.domain.users.dto.response.GetUserStatisticsRes;
 import com.ureca.uble.domain.users.dto.response.UpdateUserInfoRes;
 import com.ureca.uble.domain.users.service.UserService;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -56,5 +50,18 @@ public class UserController {
 		@RequestParam Double longitude
 	){
 		return CommonResponse.success(userService.getRecommendations(userId, latitude, longitude));
+	}
+
+	/**
+	 * 사용자 통계 정보 조회
+	 *
+	 * @param userId 사용자 정보
+	 */
+	@Operation(summary = "사용자 통계 정보 조회", description = "마이페이지에 표시될 사용자 정보를 조회합니다.")
+	@GetMapping("/statistics")
+	public CommonResponse<GetUserStatisticsRes> getUserStatistics(
+		@Parameter(description = "사용자정보", required = true)
+		@AuthenticationPrincipal Long userId) {
+		return CommonResponse.success(userService.getUserStatistics(userId));
 	}
 }

--- a/src/main/java/com/ureca/uble/domain/users/dto/response/BenefitUsageComparisonRes.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/response/BenefitUsageComparisonRes.java
@@ -1,0 +1,28 @@
+package com.ureca.uble.domain.users.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "성별/나이별 평균 대비 사용량")
+public class BenefitUsageComparisonRes {
+
+    @Schema(description = "평균 사용량", example = "8.7")
+    private double averageUsageCount;
+
+    @Schema(description = "사용자 사용량", example = "15")
+    private int userUsageCount;
+
+    @Schema(description = "평균 대비 N% 더/덜 사용", example = "72.4")
+    private double averageDiffPercent;
+
+    public static BenefitUsageComparisonRes of(double averageUsageCount, int userUsageCount) {
+        return BenefitUsageComparisonRes.builder()
+            .averageUsageCount(averageUsageCount)
+            .userUsageCount(userUsageCount)
+            .averageDiffPercent(((userUsageCount - averageUsageCount) / averageUsageCount) * 100)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/users/dto/response/BenefitUsageComparisonRes.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/response/BenefitUsageComparisonRes.java
@@ -22,7 +22,7 @@ public class BenefitUsageComparisonRes {
         return BenefitUsageComparisonRes.builder()
             .averageUsageCount(averageUsageCount)
             .userUsageCount(userUsageCount)
-            .averageDiffPercent(((userUsageCount - averageUsageCount) / averageUsageCount) * 100)
+            .averageDiffPercent(averageUsageCount == 0.0 ? 0.0 : ((userUsageCount - averageUsageCount) / averageUsageCount) * 100)
             .build();
     }
 }

--- a/src/main/java/com/ureca/uble/domain/users/dto/response/BenefitUsageComparisonRes.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/response/BenefitUsageComparisonRes.java
@@ -22,7 +22,7 @@ public class BenefitUsageComparisonRes {
         return BenefitUsageComparisonRes.builder()
             .averageUsageCount(averageUsageCount)
             .userUsageCount(userUsageCount)
-            .averageDiffPercent(averageUsageCount == 0.0 ? 0.0 : ((userUsageCount - averageUsageCount) / averageUsageCount) * 100)
+            .averageDiffPercent(averageUsageCount == 0 ? 0 : ((userUsageCount - averageUsageCount) / averageUsageCount) * 100)
             .build();
     }
 }

--- a/src/main/java/com/ureca/uble/domain/users/dto/response/BenefitUsagePatternRes.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/response/BenefitUsagePatternRes.java
@@ -1,0 +1,28 @@
+package com.ureca.uble.domain.users.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "가장 많이 사용한 일시 정보")
+public class BenefitUsagePatternRes {
+
+    @Schema(description = "가장 많이 사용된 날(일)", example = "21")
+    private String mostUsedDay;
+
+    @Schema(description = "가장 많이 사용된 요일", example = "월")
+    private String mostUsedWeekday;
+
+    @Schema(description = "가장 많이 사용된 시간", example = "13")
+    private String mostUsedTime;
+
+    public static BenefitUsagePatternRes of(String mostUsedDay, String mostUsedWeekday, String mostUsedTime) {
+        return BenefitUsagePatternRes.builder()
+            .mostUsedDay(mostUsedDay)
+            .mostUsedWeekday(mostUsedWeekday)
+            .mostUsedTime(mostUsedTime)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/users/dto/response/BrandRankRes.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/response/BrandRankRes.java
@@ -1,0 +1,24 @@
+package com.ureca.uble.domain.users.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "많이 사용한 제휴처 순위 반환 DTO")
+public class BrandRankRes {
+
+    @Schema(description = "제휴처명", example = "할리스")
+    private String brandName;
+
+    @Schema(description = "사용 횟수", example = "100")
+    private long usageCount;
+
+    public static BrandRankRes of(String brandName, long usageCount) {
+        return BrandRankRes.builder()
+            .brandName(brandName)
+            .usageCount(usageCount)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/users/dto/response/CategoryRankRes.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/response/CategoryRankRes.java
@@ -1,0 +1,24 @@
+package com.ureca.uble.domain.users.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "많이 사용한 카테고리 순위 반환 DTO")
+public class CategoryRankRes {
+
+    @Schema(description = "카테고리명", example = "카페")
+    private String categoryName;
+
+    @Schema(description = "사용 횟수", example = "100")
+    private long usageCount;
+
+    public static CategoryRankRes of(String categoryName, long usageCount) {
+        return CategoryRankRes.builder()
+            .categoryName(categoryName)
+            .usageCount(usageCount)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/users/dto/response/GetUserStatisticsRes.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/response/GetUserStatisticsRes.java
@@ -1,0 +1,39 @@
+package com.ureca.uble.domain.users.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "사용자 통계 정보 반환 DTO")
+public class GetUserStatisticsRes {
+
+    @Schema(description = "많이 이용한 카테고리 순위")
+    private List<CategoryRankRes> categoryRankList;
+
+    @Schema(description = "많이 이용한 제휴처 순위")
+    private List<BrandRankRes> brandRankList;
+
+    @Schema(description = "혜택 많이 사용한 날짜/요일/시간대")
+    private BenefitUsagePatternRes benefitUsagePattern;
+
+    @Schema(description = "성별/나이별 평균 대비 사용량")
+    private BenefitUsageComparisonRes benefitUsageComparison;
+
+    @Schema(description = "월별 이용 횟수 (6개월)")
+    private List<MonthlyBenefitUsageRes> monthlyBenefitUsageList;
+
+    public static GetUserStatisticsRes of(List<CategoryRankRes> categoryRankList, List<BrandRankRes> brandRankList, BenefitUsagePatternRes benefitUsagePattern,
+                                          BenefitUsageComparisonRes benefitUsageComparison, List<MonthlyBenefitUsageRes> monthlyBenefitUsageList) {
+        return GetUserStatisticsRes.builder()
+            .categoryRankList(categoryRankList)
+            .brandRankList(brandRankList)
+            .benefitUsagePattern(benefitUsagePattern)
+            .benefitUsageComparison(benefitUsageComparison)
+            .monthlyBenefitUsageList(monthlyBenefitUsageList)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/users/dto/response/MonthlyBenefitUsageRes.java
+++ b/src/main/java/com/ureca/uble/domain/users/dto/response/MonthlyBenefitUsageRes.java
@@ -1,0 +1,27 @@
+package com.ureca.uble.domain.users.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "월별 이용 횟수 반환 DTO(6개월)")
+public class MonthlyBenefitUsageRes {
+    @Schema(description = "이용 연", example = "2025")
+    private int year;
+
+    @Schema(description = "이용 월", example = "7")
+    private int month;
+
+    @Schema(description = "이용 횟수", example = "100")
+    private long usageCount;
+
+    public static MonthlyBenefitUsageRes of(int year, int month, long usageCount) {
+        return MonthlyBenefitUsageRes.builder()
+            .year(year)
+            .month(month)
+            .usageCount(usageCount)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/users/repository/CustomUsageHistoryDocumentRepository.java
+++ b/src/main/java/com/ureca/uble/domain/users/repository/CustomUsageHistoryDocumentRepository.java
@@ -1,0 +1,8 @@
+package com.ureca.uble.domain.users.repository;
+
+import com.ureca.uble.entity.User;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+
+public interface CustomUsageHistoryDocumentRepository {
+    ElasticsearchAggregations getUsageDateAndDiffAndCount(User user);
+}

--- a/src/main/java/com/ureca/uble/domain/users/repository/CustomUsageHistoryDocumentRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/users/repository/CustomUsageHistoryDocumentRepositoryImpl.java
@@ -1,0 +1,171 @@
+package com.ureca.uble.domain.users.repository;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.CalendarInterval;
+import co.elastic.clients.elasticsearch._types.query_dsl.DateRangeQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.util.NamedValue;
+import com.ureca.uble.entity.User;
+import com.ureca.uble.entity.document.UsageHistoryDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomUsageHistoryDocumentRepositoryImpl implements CustomUsageHistoryDocumentRepository {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Override
+    public ElasticsearchAggregations getUsageDateAndDiffAndCount(User user) {
+        long userId = user.getId();
+        int currentYear = LocalDate.now().getYear();
+
+
+        // userId 필터
+        Query userFilter = Query.of(u -> u
+            .term(t -> t.field("userId").value(userId))
+        );
+
+        // 사용자 성별, 연령대의 평균 사용량 정보
+        int userAgeRange = ((currentYear - user.getBirthDate().getYear() + 1) / 10) * 10;
+        int minBirthYear = currentYear - (userAgeRange + 9) + 1;
+        int maxBirthYear = currentYear - userAgeRange + 1;
+
+        String fromBirthDate = LocalDate.of(minBirthYear, 1, 1).format(DateTimeFormatter.ISO_DATE);
+        String toBirthDate = LocalDate.of(maxBirthYear, 12, 31).format(DateTimeFormatter.ISO_DATE);
+
+        Query ageRangeFilter = DateRangeQuery.of(r -> r
+            .field("userBirthDate")
+            .gte(fromBirthDate)
+            .lte(toBirthDate)
+        )._toRangeQuery()._toQuery();
+
+        Query genderFilter = Query.of(q -> q
+            .term(t -> t.field("userGender").value(user.getGender().toString()))
+        );
+
+        Aggregation targetGroupAgg = Aggregation.of(a -> a
+            .filter(f -> f.bool(b -> b
+                .filter(List.of(ageRangeFilter, genderFilter))
+            ))
+            .aggregations(Map.of(
+                "user_count", Aggregation.of(ag -> ag.cardinality(c -> c.field("userId"))),
+                "total_count", Aggregation.of(ag -> ag.valueCount(vc -> vc.field("userId")))
+            ))
+        );
+
+        // 사용자 전체 사용량
+        Aggregation myUsageCountAgg = Aggregation.of(a -> a
+            .filter(userFilter)
+            .aggregations(Map.of(
+                "total_history_count", Aggregation.of(ag -> ag.valueCount(vc -> vc.field("userId")))
+            ))
+        );
+
+        // 월별 사용량 (6개월)
+        LocalDate nowDate = LocalDate.now();
+        String fromDate = nowDate.minusMonths(5).withDayOfMonth(1).format(DateTimeFormatter.ISO_DATE);
+
+        Query dateRangeFilter = DateRangeQuery.of(r -> r
+            .field("createdAt")
+            .gte(fromDate)
+            .lte("now")
+        )._toRangeQuery()._toQuery();
+
+        Aggregation monthlyUsageAgg = Aggregation.of(a -> a
+            .filter(f -> f
+                .bool(b -> b
+                    .filter(List.of(userFilter, dateRangeFilter))
+                )
+            )
+            .aggregations("monthly", Aggregation.of(aa -> aa
+                .dateHistogram(dh -> dh
+                    .field("createdAt")
+                    .calendarInterval(CalendarInterval.Month)
+                    .format("yyyy-MM")
+                    .timeZone("Asia/Seoul")
+                    .minDocCount(0)
+                )
+            ))
+        );
+
+        // 가장 많이 사용한 날
+        Aggregation mostUsedDayOfMonthAgg = Aggregation.of(a -> a
+            .filter(userFilter)
+            .aggregations("by_day", Aggregation.of(aa -> aa
+                .terms(t -> t
+                    .script(s -> s
+                        .source("doc['createdAt'].value.getDayOfMonth()")
+                        .lang("painless")
+                    )
+                    .size(1)
+                    .order(List.of(NamedValue.of("_count", SortOrder.Desc)))
+                )
+            ))
+        );
+
+        // 가장 많이 사용한 요일
+        Aggregation mostUsedWeekdayAgg = Aggregation.of(a -> a
+            .filter(userFilter)
+            .aggregations("weekday", Aggregation.of(aa -> aa
+                .terms(t -> t
+                    .script(s -> s
+                        .source("""
+                            int d = doc['createdAt'].value.getDayOfWeek().getValue();
+                            if (d == 1) return '월';
+                            if (d == 2) return '화';
+                            if (d == 3) return '수';
+                            if (d == 4) return '목';
+                            if (d == 5) return '금';
+                            if (d == 6) return '토';
+                            if (d == 7) return '일';
+                            return '';
+                        """)
+                        .lang("painless")
+                    )
+                    .size(1)
+                    .order(List.of(NamedValue.of("_count", SortOrder.Desc)))
+                )
+            ))
+        );
+
+        // 가장 많이 사용한 시간
+        Aggregation mostUsedHourAgg = Aggregation.of(a -> a
+            .filter(userFilter)
+            .aggregations("hour", Aggregation.of(aa -> aa
+                .terms(t -> t
+                    .script(s -> s
+                        .source("doc['createdAt'].value.getHour()")
+                        .lang("painless")
+                    )
+                    .size(1)
+                    .order(List.of(NamedValue.of("_count", SortOrder.Desc)))
+                )
+            ))
+        );
+
+        // 최종 쿼리 생성
+        NativeQuery query = NativeQuery.builder()
+            .withAggregation("target_group", targetGroupAgg)
+            .withAggregation("my_usage_count", myUsageCountAgg)
+            .withAggregation("monthly_usage", monthlyUsageAgg)
+            .withAggregation("most_used_day_of_month", mostUsedDayOfMonthAgg)
+            .withAggregation("most_used_weekday", mostUsedWeekdayAgg)
+            .withAggregation("most_used_hour", mostUsedHourAgg)
+            .withMaxResults(0)
+            .build();
+
+        // 검색 및 반환
+        return (ElasticsearchAggregations) elasticsearchOperations.search(query, UsageHistoryDocument.class).getAggregations();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/users/repository/UsageHistoryDocumentRepository.java
+++ b/src/main/java/com/ureca/uble/domain/users/repository/UsageHistoryDocumentRepository.java
@@ -3,5 +3,5 @@ package com.ureca.uble.domain.users.repository;
 import com.ureca.uble.entity.document.UsageHistoryDocument;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface UsageHistoryDocumentRepository extends ElasticsearchRepository<UsageHistoryDocument, String> {
+public interface UsageHistoryDocumentRepository extends ElasticsearchRepository<UsageHistoryDocument, String>, CustomUsageHistoryDocumentRepository {
 }

--- a/src/main/java/com/ureca/uble/domain/users/service/UserService.java
+++ b/src/main/java/com/ureca/uble/domain/users/service/UserService.java
@@ -1,26 +1,27 @@
 package com.ureca.uble.domain.users.service;
 
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClient;
-
+import com.ureca.uble.domain.brand.repository.BrandClickLogDocumentRepository;
 import com.ureca.uble.domain.category.repository.CategoryRepository;
 import com.ureca.uble.domain.users.dto.request.UpdateUserInfoReq;
-import com.ureca.uble.domain.users.dto.response.GetRecommendationListRes;
-import com.ureca.uble.domain.users.dto.response.GetUserInfoRes;
-import com.ureca.uble.domain.users.dto.response.UpdateUserInfoRes;
+import com.ureca.uble.domain.users.dto.response.*;
 import com.ureca.uble.domain.users.exception.UserErrorCode;
+import com.ureca.uble.domain.users.repository.UsageHistoryDocumentRepository;
 import com.ureca.uble.domain.users.repository.UserCategoryRepository;
 import com.ureca.uble.domain.users.repository.UserRepository;
 import com.ureca.uble.entity.Category;
 import com.ureca.uble.entity.User;
 import com.ureca.uble.entity.UserCategory;
 import com.ureca.uble.global.exception.GlobalException;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +31,12 @@ public class UserService {
 	private final UserCategoryRepository userCategoryRepository;
 	private final CategoryRepository categoryRepository;
 	private final WebClient fastapiWebClient;
+	private final BrandClickLogDocumentRepository brandClickLogDocumentRepository;
+	private final UsageHistoryDocumentRepository usageHistoryDocumentRepository;
 
+	/**
+	 * 사용자 정보 조회
+	 */
 	@Transactional(readOnly = true)
 	public GetUserInfoRes getUserInfo(Long userId) {
 		User user = findUser(userId);
@@ -42,6 +48,9 @@ public class UserService {
 		return GetUserInfoRes.of(user, categoryIds);
 	}
 
+	/**
+	 * 사용자 정보 갱신
+	 */
 	@Transactional
 	public UpdateUserInfoRes updateUserInfo(Long userId, UpdateUserInfoReq request) {
 		User user = findUser(userId);
@@ -64,11 +73,9 @@ public class UserService {
 		return UpdateUserInfoRes.of(user, request.getCategoryIds());
 	}
 
-	private User findUser(Long userId){
-		return userRepository.findById(userId)
-			.orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
-	}
-
+	/**
+	 * 사용자 맞춤 추천
+	 */
 	public GetRecommendationListRes getRecommendations(Long userId, Double latitude, Double longitude) {
 		if (userId == null || latitude == null || longitude == null){
 			throw new GlobalException(UserErrorCode.INVALID_PARAMETER);
@@ -90,5 +97,65 @@ public class UserService {
 		} catch (Exception e) {
 			throw new GlobalException(UserErrorCode.EXTERNAL_API_ERROR);
 		}
+	}
+
+	/**
+	 * 개인 통계 전체 조회
+	 */
+	@Transactional(readOnly = true)
+	public GetUserStatisticsRes getUserStatistics(Long userId) {
+		User user = findUser(userId);
+
+		ElasticsearchAggregations rankResult = brandClickLogDocumentRepository.getCategoryAndBrandRankByUserId(userId);
+		ElasticsearchAggregations usageResult = usageHistoryDocumentRepository.getUsageDateAndDiffAndCount(user);
+
+		// 카테고리 순위
+		List<CategoryRankRes> categoryRankList = rankResult.aggregationsAsMap().get("category_rank").aggregation()
+			.getAggregate().sterms().buckets().array().stream()
+			.map(b -> CategoryRankRes.of(b.key().stringValue(), b.docCount()))
+			.toList();
+
+		// 제휴처 순위
+		List<BrandRankRes> brandRankList = rankResult.aggregationsAsMap().get("brand_rank").aggregation()
+			.getAggregate().sterms().buckets().array().stream()
+			.map(b -> BrandRankRes.of(b.key().stringValue(), b.docCount()))
+			.toList();
+
+		// 가장 많이 사용한 날(일)
+		String mostUsedDay = usageResult.aggregationsAsMap().get("most_used_day_of_month").aggregation().getAggregate().filter().aggregations()
+			.get("by_day").sterms().buckets().array().stream().findFirst().map(b -> b.key().stringValue()).orElse(null);
+
+		String mostUsedWeekDay = usageResult.aggregationsAsMap().get("most_used_weekday").aggregation().getAggregate().filter().aggregations()
+			.get("weekday").sterms().buckets().array().stream().findFirst().map(b -> b.key().stringValue()).orElse(null);
+
+		String mostUsedTime = usageResult.aggregationsAsMap().get("most_used_hour").aggregation().getAggregate().filter().aggregations()
+			.get("hour").sterms().buckets().array().stream().findFirst().map(b -> b.key().stringValue()).orElse(null);
+
+		BenefitUsagePatternRes benefitUsagePatternRes = BenefitUsagePatternRes.of(mostUsedDay, mostUsedWeekDay, mostUsedTime);
+
+		// 성별나이 평균 대비 사용 횟수
+		double totalCount = usageResult.aggregationsAsMap().get("target_group").aggregation()
+			.getAggregate().filter().aggregations().get("total_count").valueCount().value();
+		double totalUserCount = usageResult.aggregationsAsMap().get("target_group").aggregation()
+			.getAggregate().filter().aggregations().get("user_count").cardinality().value();
+		int userHistoryCount = (int) usageResult.aggregationsAsMap().get("my_usage_count").aggregation()
+			.getAggregate().filter().aggregations().get("total_history_count").valueCount().value();
+
+		BenefitUsageComparisonRes benefitUsageComparisonRes = BenefitUsageComparisonRes.of(totalCount / totalUserCount, userHistoryCount);
+
+		// 월별 사용 횟수 (6개월)
+		List<MonthlyBenefitUsageRes> monthlyBenefitUsageList = usageResult.aggregationsAsMap().get("monthly_usage").aggregation().getAggregate().filter().aggregations()
+			.get("monthly").dateHistogram().buckets().array().stream()
+			.map(b -> {
+				YearMonth ym = YearMonth.parse(b.keyAsString(), DateTimeFormatter.ofPattern("yyyy-MM"));
+				return MonthlyBenefitUsageRes.of(ym.getYear(), ym.getMonthValue(), b.docCount());
+			}).toList();
+
+		return GetUserStatisticsRes.of(categoryRankList, brandRankList, benefitUsagePatternRes, benefitUsageComparisonRes, monthlyBenefitUsageList);
+	}
+
+	private User findUser(Long userId){
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,13 @@ spring:
     username: ${ELASTIC_USERNAME}
     password: ${ELASTIC_PASSWORD}
 
+springdoc:
+  swagger-ui:
+    enabled: true
+    tagsSorter: alpha
+    operations-sorter: alpha
+    display-request-duration: true
+
 logging:
   level:
     org.elasticsearch.client: TRACE


### PR DESCRIPTION
## #️⃣연관된 이슈

> #70 

## 📝작업 내용
- 개인 통계 조회용 API를 구현하였습니다.
    - 많이 이용한 카테고리 순위
    - 많이 이용한 제휴처 순위
    - 혜택 많이 사용한 날짜/요일/시간대
    - 성별/나이별 평균 대비 사용량
    - 월별 이용 횟수 (6개월)
- 전체 통계를 한번에 불러오는 API → 동일 index에 대한 통계를 한 번의 요청으로 묶어 보내도록 하였습니다.

## 📷스크린샷 (선택)


## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지에서 확인할 수 있는 사용자 통계 조회 기능이 추가되었습니다.  
    - 카테고리 및 브랜드별 사용 순위, 혜택 사용 패턴(요일, 시간대 등), 성별 및 연령대별 평균과의 비교, 최근 6개월간 월별 사용량 등 다양한 통계 정보를 제공합니다.
  * 사용자 통계 API가 추가되어, 상세한 사용 내역 및 비교 데이터를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->