### PR TITLE
[Feat] 매장 소모달 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/ureca/uble/domain/store/controller/StoreController.java
+++ b/src/main/java/com/ureca/uble/domain/store/controller/StoreController.java
@@ -1,16 +1,23 @@
 package com.ureca.uble.domain.store.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ureca.uble.domain.common.dto.response.CommonResponse;
 import com.ureca.uble.domain.store.dto.response.GetStoreDetailRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
+import com.ureca.uble.domain.store.dto.response.GetStoreSummaryRes;
 import com.ureca.uble.domain.store.service.StoreService;
 import com.ureca.uble.entity.enums.BenefitType;
 import com.ureca.uble.entity.enums.Season;
-import com.ureca.uble.domain.common.dto.response.CommonResponse;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/stores")
@@ -48,6 +55,28 @@ public class StoreController {
         @Parameter(description = "혜택 타입 필터링(LOCAL/VIP)")
         @RequestParam(required = false) BenefitType type) {
         return CommonResponse.success(storeService.getStores(latitude, longitude, distance, categoryId, brandId, season, type));
+    }
+
+    /**
+     * 매장 소모달 정보 조회
+     *
+     * @param latitude 위도
+     * @param longitude 경도
+     * @param userId 사용자 정보
+     * @param storeId 매장 id
+     */
+    @Operation(summary = "매장 소모달 정보 조회", description = "매장 소모달 정보 조회")
+    @GetMapping("summary/{storeId}")
+    public CommonResponse<GetStoreSummaryRes> getStoreSummary(
+        @Parameter(description = "위도", required = true)
+        @RequestParam double latitude,
+        @Parameter(description = "경도", required = true)
+        @RequestParam double longitude,
+        @Parameter(description = "사용자정보", required = true)
+        @AuthenticationPrincipal Long userId,
+        @Parameter(description = "매장 id", required = true)
+        @PathVariable Long storeId) {
+        return CommonResponse.success(storeService.getStoreSummary(latitude, longitude, userId, storeId));
     }
 
     /**

--- a/src/main/java/com/ureca/uble/domain/store/dto/response/GetStoreDetailRes.java
+++ b/src/main/java/com/ureca/uble/domain/store/dto/response/GetStoreDetailRes.java
@@ -1,11 +1,13 @@
 package com.ureca.uble.domain.store.dto.response;
 
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ureca.uble.entity.Store;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 @Getter
 @Builder
@@ -47,11 +49,15 @@ public class GetStoreDetailRes {
     @Schema(description = "(사용자) 우리 동네 멤버십 혜택 사용 가능 여부", example = "false")
     private boolean isLocalAvailable;
 
+    @Schema(description = "북마크 여부", example = "true")
+    @JsonProperty("isBookmarked")
+    private boolean bookmarked;
+
     @Schema(description = "혜택 리스트", example = "혜택 리스트")
     private List<GetBenefitInfoRes> benefitList;
 
     public static GetStoreDetailRes of(Store store,Double distance, boolean isNormalAvailable, boolean isVipAvailable,
-                                       boolean isLocalAvailable, List<GetBenefitInfoRes> benefitList) {
+                                       boolean isLocalAvailable, boolean bookmarked, List<GetBenefitInfoRes> benefitList) {
         return GetStoreDetailRes.builder()
             .brandId(store.getBrand().getId())
             .storeId(store.getId())
@@ -65,6 +71,7 @@ public class GetStoreDetailRes {
             .isNormalAvailable(isNormalAvailable)
             .isVipAvailable(isVipAvailable)
             .isLocalAvailable(isLocalAvailable)
+            .bookmarked(bookmarked)
             .benefitList(benefitList)
             .build();
     }

--- a/src/main/java/com/ureca/uble/domain/store/dto/response/GetStoreSummaryRes.java
+++ b/src/main/java/com/ureca/uble/domain/store/dto/response/GetStoreSummaryRes.java
@@ -1,0 +1,59 @@
+package com.ureca.uble.domain.store.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ureca.uble.entity.Store;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "매장 소모달 정보 반환 DTO")
+public class GetStoreSummaryRes {
+    @Schema(description = "제휴처 id", example = "123")
+    private Long brandId;
+
+    @Schema(description = "매장 id", example = "123")
+    private Long storeId;
+
+    @Schema(description = "매장 이름", example = "스타벅스 선릉점")
+    private String storeName;
+
+    @Schema(description = "매장 설명", example = "커피가 맛있는 스타벅스")
+    private String description;
+
+    @Schema(description = "매장 대표 연락처", example = "02-1234-5678")
+    private String phoneNumber;
+
+    @Schema(description = "매장 주소", example = "서울 강남구 테헤란로64길 18")
+    private String address;
+
+    @Schema(description = "매장까지의 거리 (m 기준)", example = "900.123")
+    private Double distance;
+
+    @Schema(description = "카테고리", example = "음식점")
+    private String category;
+
+    @Schema(description = "대표 이미지 URL", example = "https://example.com")
+    private String imageUrl;
+
+    @Schema(description = "북마크 여부", example = "true")
+    @JsonProperty("isBookmarked")
+    private boolean bookmarked;
+
+    public static GetStoreSummaryRes of(Store store, Double distance, boolean bookmarked) {
+        return GetStoreSummaryRes.builder()
+            .brandId(store.getBrand().getId())
+            .storeId(store.getId())
+            .storeName(store.getName())
+            .description(store.getBrand().getDescription())
+            .phoneNumber(store.getPhoneNumber())
+            .address(store.getAddress())
+            .distance(distance)
+            .category(store.getBrand().getCategory().getName())
+            .imageUrl(store.getBrand().getImageUrl())
+            .bookmarked(bookmarked)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
+++ b/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
@@ -1,31 +1,42 @@
 package com.ureca.uble.domain.store.service;
 
-import com.ureca.uble.domain.store.dto.response.GetBenefitInfoRes;
-import com.ureca.uble.domain.store.dto.response.GetStoreDetailRes;
-import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
-import com.ureca.uble.domain.store.dto.response.GetStoreRes;
-import com.ureca.uble.domain.store.repository.StoreClickLogDocumentRepository;
-import com.ureca.uble.domain.store.repository.StoreRepository;
-import com.ureca.uble.domain.users.repository.UsageCountRepository;
-import com.ureca.uble.domain.users.repository.UserRepository;
-import com.ureca.uble.entity.*;
-import com.ureca.uble.entity.document.StoreClickLogDocument;
-import com.ureca.uble.entity.enums.*;
-import com.ureca.uble.global.exception.GlobalException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import static com.ureca.uble.domain.store.exception.StoreErrorCode.*;
+import static com.ureca.uble.domain.users.exception.UserErrorCode.*;
+
+import java.util.List;
+import java.util.Optional;
+
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
+import com.ureca.uble.domain.bookmark.repository.BookmarkRepository;
+import com.ureca.uble.domain.store.dto.response.GetBenefitInfoRes;
+import com.ureca.uble.domain.store.dto.response.GetStoreDetailRes;
+import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
+import com.ureca.uble.domain.store.dto.response.GetStoreRes;
+import com.ureca.uble.domain.store.dto.response.GetStoreSummaryRes;
+import com.ureca.uble.domain.store.repository.StoreClickLogDocumentRepository;
+import com.ureca.uble.domain.store.repository.StoreRepository;
+import com.ureca.uble.domain.users.repository.UsageCountRepository;
+import com.ureca.uble.domain.users.repository.UserRepository;
+import com.ureca.uble.entity.Benefit;
+import com.ureca.uble.entity.Brand;
+import com.ureca.uble.entity.Store;
+import com.ureca.uble.entity.UsageCount;
+import com.ureca.uble.entity.User;
+import com.ureca.uble.entity.document.StoreClickLogDocument;
+import com.ureca.uble.entity.enums.BenefitType;
+import com.ureca.uble.entity.enums.Period;
+import com.ureca.uble.entity.enums.Rank;
+import com.ureca.uble.entity.enums.RankType;
+import com.ureca.uble.entity.enums.Season;
+import com.ureca.uble.global.exception.GlobalException;
 
-import static com.ureca.uble.domain.store.exception.StoreErrorCode.OUT_OF_RANGE_INPUT;
-import static com.ureca.uble.domain.store.exception.StoreErrorCode.STORE_NOT_FOUND;
-import static com.ureca.uble.domain.users.exception.UserErrorCode.USER_NOT_FOUND;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -35,6 +46,7 @@ public class StoreService {
     private final UserRepository userRepository;
     private final UsageCountRepository usageCountRepository;
     private final StoreRepository storeRepository;
+    private final BookmarkRepository bookmarkRepository;
     private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
     private final StoreClickLogDocumentRepository storeClickLogDocumentRepository;
 
@@ -49,6 +61,22 @@ public class StoreService {
             .stream().map(GetStoreRes::from).toList();
 
         return new GetStoreListRes(storeList);
+    }
+
+    /**
+     * 매장 소모달 정보 조회
+     */
+    public GetStoreSummaryRes getStoreSummary(double latitude, double longitude, Long userId, Long storeId) {
+        User user = findUser(userId);
+        Store store = findByIdWithBrandAndCategoryAndBenefits(storeId);
+
+        // 좌표 기준 거리 계산
+        Double distance = calculateDistance(store.getLocation().getY(), store.getLocation().getX(), latitude, longitude);
+
+        // 북마크 여부
+        boolean isBookmarked = bookmarkRepository.existsByBrand_IdAndUser_Id(userId, store.getBrand().getId());
+
+        return GetStoreSummaryRes.of(store, distance, isBookmarked);
     }
 
     /**
@@ -67,6 +95,9 @@ public class StoreService {
         boolean isVipAvailable = (type == RankType.VIP || type == RankType.VIP_NORMAL) && handleVipBenefit(user);
         boolean isLocalAvailable = (type == RankType.LOCAL) && handleLocalBenefit(user);
 
+        // 북마크 여부
+        boolean isBookmarked = bookmarkRepository.existsByBrand_IdAndUser_Id(userId, store.getBrand().getId());
+
         // 혜택 List 계산
         List<GetBenefitInfoRes> benefitList = store.getBrand().getBenefits().stream()
             .map(b -> GetBenefitInfoRes.of(b, getBenefitType(store.getBrand(), b)))
@@ -79,7 +110,7 @@ public class StoreService {
             log.warn("매장 상세 조회 로그 저장에 실패하였습니다 : {}", e.getMessage());
         }
 
-        return GetStoreDetailRes.of(store, distance, isNormalAvailable, isVipAvailable, isLocalAvailable, benefitList);
+        return GetStoreDetailRes.of(store, distance, isNormalAvailable, isVipAvailable, isLocalAvailable, isBookmarked, benefitList);
     }
 
     private BenefitType getBenefitType(Brand brand, Benefit benefit) {
@@ -140,4 +171,6 @@ public class StoreService {
     private User findUser(Long userId) {
         return userRepository.findById(userId).orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
     }
+
+
 }

--- a/src/test/java/com/ureca/uble/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/store/service/StoreServiceTest.java
@@ -1,7 +1,9 @@
 package com.ureca.uble.domain.store.service;
 
+import com.ureca.uble.domain.bookmark.repository.BookmarkRepository;
 import com.ureca.uble.domain.store.dto.response.GetStoreDetailRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
+import com.ureca.uble.domain.store.dto.response.GetStoreSummaryRes;
 import com.ureca.uble.domain.store.repository.StoreClickLogDocumentRepository;
 import com.ureca.uble.domain.store.repository.StoreRepository;
 import com.ureca.uble.domain.users.repository.UsageCountRepository;
@@ -48,6 +50,9 @@ class StoreServiceTest {
     @Mock
     private StoreClickLogDocumentRepository storeClickLogDocumentRepository;
 
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+
     @Test
     @DisplayName("반경 500m 내의 매장 중 필터링 조건에 맞는 매장 리스트를 조회한다.")
     void getStores_get_check() {
@@ -85,6 +90,55 @@ class StoreServiceTest {
         assertNotNull(result);
         assertEquals(1, result.getStoreList().size());
         assertEquals("테스트 선릉점", result.getStoreList().get(0).getStoreName());
+    }
+
+    @Test
+    @DisplayName("매장 소모달 정보를 조회한다.")
+    void getStoreSummarySuccess() {
+        // given
+        Double latitude = 37.5;
+        Double longitude = 127.0;
+        Long userId = 1L;
+        Long storeId = 10L;
+
+        User mockUser = mock(User.class);
+        Brand mockBrand = mock(Brand.class);
+        Category mockCategory = mock(Category.class);
+        Store mockStore = mock(Store.class);
+        Point mockLocation = mock(Point.class);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(storeRepository.findByIdWithBrandAndCategoryAndBenefits(storeId)).thenReturn(Optional.of(mockStore));
+
+        when(mockStore.getBrand()).thenReturn(mockBrand);
+        when(mockStore.getId()).thenReturn(storeId);
+        when(mockStore.getName()).thenReturn("스타벅스 선릉점");
+        when(mockStore.getAddress()).thenReturn("서울 강남구 테헤란로64길 18");
+        when(mockStore.getPhoneNumber()).thenReturn("02-1234-5678");
+        when(mockStore.getLocation()).thenReturn(mockLocation);
+        when(mockLocation.getY()).thenReturn(37.0);
+        when(mockLocation.getX()).thenReturn(127.0);
+        when(mockBrand.getId()).thenReturn(123L);
+        when(mockBrand.getDescription()).thenReturn("커피가 맛있는 스타벅스");
+        when(mockBrand.getImageUrl()).thenReturn("https://example.com");
+        when(mockBrand.getCategory()).thenReturn(mockCategory);
+        when(mockCategory.getName()).thenReturn("음식점");
+
+        when(bookmarkRepository.existsByBrand_IdAndUser_Id(userId, mockBrand.getId())).thenReturn(true);
+
+        // when
+        GetStoreSummaryRes result = storeService.getStoreSummary(latitude, longitude, userId, storeId);
+
+        // then
+        assertThat(result.getBrandId()).isEqualTo(123L);
+        assertThat(result.getStoreId()).isEqualTo(storeId);
+        assertThat(result.getStoreName()).isEqualTo("스타벅스 선릉점");
+        assertThat(result.getDescription()).isEqualTo("커피가 맛있는 스타벅스");
+        assertThat(result.getAddress()).isEqualTo("서울 강남구 테헤란로64길 18");
+        assertThat(result.getPhoneNumber()).isEqualTo("02-1234-5678");
+        assertThat(result.getCategory()).isEqualTo("음식점");
+        assertThat(result.getImageUrl()).isEqualTo("https://example.com");
+        assertThat(result.isBookmarked()).isTrue();
     }
 
     @Test
@@ -131,6 +185,7 @@ class StoreServiceTest {
         when(mockBenefit.getManual()).thenReturn("매장 방문 시 쿠폰 제시");
         when(mockBenefit.getPeriod()).thenReturn(com.ureca.uble.entity.enums.Period.MONTHLY);
         when(mockBenefit.getNumber()).thenReturn(1);
+        when(bookmarkRepository.existsByBrand_IdAndUser_Id(userId, mockBrand.getId())).thenReturn(true);
 
         // when
         GetStoreDetailRes result = storeService.getStoreDetail(latitude, longitude, userId, storeId);
@@ -148,6 +203,8 @@ class StoreServiceTest {
         assertThat(result.getBenefitList().get(0).getBenefitId()).isEqualTo(1001L);
         assertThat(result.getBenefitList().get(0).getType()).isEqualTo("NORMAL");
         assertThat(result.getBenefitList().get(0).getContent()).isEqualTo("아메리카노 무료");
+        assertThat(result.isBookmarked()).isTrue();
+
         verify(storeClickLogDocumentRepository).save(any(StoreClickLogDocument.class));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #87 

## 📝작업 내용

> 매장 소모달 정보 조회 API를 구현하였습니다. 
매장 상세 정보 조회 API에 북마크여부를 추가하였습니다. 

## 📷스크린샷 (선택)

> 

## 💬리뷰 요구사항(선택)

> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매장 요약 정보를 제공하는 새로운 API 엔드포인트가 추가되었습니다.
  * 매장 상세 및 요약 정보에 북마크 여부 표시가 추가되었습니다.

* **버그 수정**
  * 매장 상세 및 요약 정보 조회 시 북마크 상태가 정확하게 반영되도록 개선되었습니다.

* **테스트**
  * 매장 요약 및 상세 정보에 대한 북마크 상태 검증 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->