### PR TITLE
[Feat] 지도 내 자동완성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ dependencies {
 
     // elasticsearch
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation "co.elastic.clients:elasticsearch-java:8.18.1"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ureca/uble/domain/brand/service/BrandService.java
+++ b/src/main/java/com/ureca/uble/domain/brand/service/BrandService.java
@@ -1,20 +1,23 @@
 package com.ureca.uble.domain.brand.service;
 
+import co.elastic.clients.elasticsearch.core.MsearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.ureca.uble.domain.bookmark.repository.BookmarkRepository;
 import com.ureca.uble.domain.brand.dto.response.*;
 import com.ureca.uble.domain.brand.exception.BrandErrorCode;
 import com.ureca.uble.domain.brand.repository.BrandClickLogDocumentRepository;
 import com.ureca.uble.domain.brand.repository.BrandNoriDocumentRepository;
 import com.ureca.uble.domain.brand.repository.BrandRepository;
-import com.ureca.uble.domain.brand.repository.BrandSuggestionDocumentRepository;
-import com.ureca.uble.domain.category.repository.CategorySuggestionDocumentRepository;
 import com.ureca.uble.domain.common.dto.response.CursorPageRes;
+import com.ureca.uble.domain.common.repository.CustomSuggestionRepository;
 import com.ureca.uble.domain.store.repository.SearchLogDocumentRepository;
 import com.ureca.uble.domain.users.repository.UserRepository;
 import com.ureca.uble.entity.Bookmark;
 import com.ureca.uble.entity.Brand;
 import com.ureca.uble.entity.User;
-import com.ureca.uble.entity.document.*;
+import com.ureca.uble.entity.document.BrandClickLogDocument;
+import com.ureca.uble.entity.document.BrandNoriDocument;
+import com.ureca.uble.entity.document.SearchLogDocument;
 import com.ureca.uble.entity.enums.*;
 import com.ureca.uble.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
@@ -23,14 +26,12 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.ureca.uble.domain.users.exception.UserErrorCode.USER_NOT_FOUND;
+import static com.ureca.uble.global.exception.GlobalErrorCode.ELASTIC_INTERNAL_ERROR;
 
 @Slf4j
 @Service
@@ -43,8 +44,7 @@ public class BrandService {
 	private final BrandClickLogDocumentRepository brandClickLogDocumentRepository;
 	private final UserRepository userRepository;
 	private final SearchLogDocumentRepository searchLogDocumentRepository;
-	private final CategorySuggestionDocumentRepository categorySuggestionDocumentRepository;
-	private final BrandSuggestionDocumentRepository brandSuggestionDocumentRepository;
+	private final CustomSuggestionRepository customSuggestionRepository;
 
 	/**
 	 * 제휴처 상세 조회
@@ -167,16 +167,31 @@ public class BrandService {
 	 * 제휴처 검색 자동완성
 	 */
 	public BrandSuggestionListRes getBrandSuggestionList(String keyword, int size) {
-		// category 조회
-		SearchHits<CategorySuggestionDocument> categoryHits = categorySuggestionDocumentRepository.findByKeywordAndLimit(keyword, 2);
-		List<SuggestionRes> res = new ArrayList<>(categoryHits.getSearchHits().stream()
-            .map(hit -> SuggestionRes.of(hit.getContent().getCategoryName(), SuggestionType.CATEGORY))
-            .toList());
+		MsearchResponse<Map> response;
+		try {
+			response = customSuggestionRepository.findBrandSuggestionsByKeywordWithMsearch(keyword, 2, size - 2);
+		} catch (Exception e) {
+			throw new GlobalException(ELASTIC_INTERNAL_ERROR);
+		}
+
+		List<SuggestionRes> res = new ArrayList<>();
+
+		// 카테고리 매핑
+		res.addAll(response.responses().get(0).result().hits().hits().stream()
+			.map(Hit::source).filter(Objects::nonNull)
+			.map(source -> SuggestionRes.of(
+				(String) source.get("categoryName"),
+				SuggestionType.CATEGORY
+			))
+			.toList());
 
 		// brand 조회
-		SearchHits<BrandSuggestionDocument> brandHits = brandSuggestionDocumentRepository.findByKeywordAndLimit(keyword, size - res.size());
-		res.addAll(brandHits.getSearchHits().stream()
-			.map(hit -> SuggestionRes.of(hit.getContent().getBrandName(), SuggestionType.BRAND))
+		res.addAll(response.responses().get(1).result().hits().hits().stream()
+			.map(Hit::source).filter(Objects::nonNull)
+			.map(source -> SuggestionRes.of(
+				(String) source.get("brandName"),
+				SuggestionType.BRAND
+			))
 			.toList());
 
 		return new BrandSuggestionListRes(res);

--- a/src/main/java/com/ureca/uble/domain/common/repository/CustomSuggestionRepository.java
+++ b/src/main/java/com/ureca/uble/domain/common/repository/CustomSuggestionRepository.java
@@ -1,0 +1,168 @@
+package com.ureca.uble.domain.common.repository;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.GeoLocation;
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import co.elastic.clients.elasticsearch.core.MsearchRequest;
+import co.elastic.clients.elasticsearch.core.MsearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomSuggestionRepository {
+
+    private final ElasticsearchClient elasticsearchClient;
+
+    /**
+     * 카테고리, 재휴처 자동완성
+     */
+    public MsearchResponse<Map> findBrandSuggestionsByKeywordWithMsearch(String keyword, int categorySize, int brandSize) throws IOException {
+        MsearchRequest request = new MsearchRequest.Builder()
+            .searches(s -> s
+                .header(h -> h.index("category-suggestion"))
+                .body(b -> b
+                    .size(categorySize)
+                    .query(getCategoryQuery(keyword))
+                )
+            )
+            .searches(s -> s
+                .header(h -> h.index("brand-suggestion"))
+                .body(b -> b
+                    .size(brandSize)
+                    .query(getBrandQuery(keyword, false))
+                )
+            )
+            .build();
+        return elasticsearchClient.msearch(request, Map.class);
+    }
+
+    /**
+     * 카테고리, 재휴처, 매장 자동완성
+     */
+    public MsearchResponse<Map> findMapSuggestionsByKeywordWithMsearch(String keyword, int categorySize, int brandSize, int storeSize, double latitude, double longitude) throws IOException {
+        MsearchRequest request = new MsearchRequest.Builder()
+            .searches(s -> s
+                .header(h -> h.index("category-suggestion"))
+                .body(b -> b
+                    .size(categorySize)
+                    .query(getCategoryQuery(keyword))
+                )
+            )
+            .searches(s -> s
+                .header(h -> h.index("brand-suggestion"))
+                .body(b -> b
+                    .size(brandSize)
+                    .query(getBrandQuery(keyword, true))
+                )
+            )
+            .searches(s -> s
+                .header(h -> h.index("store-suggestion"))
+                .body(b -> b
+                    .size(storeSize)
+                    .minScore(5.0)
+                    .query(getStoreQuery(keyword, latitude, longitude))
+                )
+            )
+            .build();
+        return elasticsearchClient.msearch(request, Map.class);
+    }
+
+    private Query getCategoryQuery(String keyword) {
+        return MultiMatchQuery.of(m -> m
+            .query(keyword)
+            .fields("categoryName","categoryName._2gram", "categoryName._3gram")
+            .type(TextQueryType.BestFields)
+            .fuzziness("1")
+        )._toQuery();
+    }
+
+    private Query getBrandQuery(String keyword, boolean isOnlineOnly) {
+        Query multiMatchQuery = MultiMatchQuery.of(m -> m
+            .query(keyword)
+            .fields(
+                "brandName^5",
+                "brandName._2gram^5",
+                "brandName._3gram^5",
+                "category",
+                "category._2gram",
+                "category._3gram",
+                "season",
+                "season._2gram"
+            )
+            .type(TextQueryType.BestFields)
+        )._toQuery();
+
+        if (isOnlineOnly) {
+            return BoolQuery.of(b -> b
+                .must(multiMatchQuery)
+                .filter(f -> f
+                    .term(t -> t
+                        .field("isOnline")
+                        .value(false)
+                    )
+                )
+            )._toQuery();
+        }
+        return multiMatchQuery;
+    }
+
+    private Query getStoreQuery(String keyword, double latitude, double longitude) {
+        List<String> tokens = List.of(keyword.split(" "));
+
+        // 각 토큰을 should 쿼리로 변환
+        List<Query> shouldQueries = tokens.stream()
+            .map(token -> MultiMatchQuery.of(q -> q
+                .query(token)
+                .type(TextQueryType.BoolPrefix)
+                .fields(List.of(
+                    "brandName", "brandName._2gram", "brandName._3gram",
+                    "storeName", "storeName._2gram", "storeName._3gram",
+                    "category", "category._2gram", "category._3gram",
+                    "season", "season._2gram", "season._3gram",
+                    "address"
+                ))
+            )._toQuery()
+        ).toList();
+
+        Query boolQuery = Query.of(q -> q
+            .bool(b -> b
+                .should(shouldQueries)
+                .minimumShouldMatch("1")
+            )
+        );
+
+        // 위치 정보
+        GeoLocation geoLocation = GeoLocation.of(gl -> gl
+            .latlon(ll -> ll.lat(latitude).lon(longitude))
+        );
+
+        FunctionScore gaussFunction = FunctionScore.of(fs -> fs
+            .gauss(df -> df
+                .geo(g -> g
+                    .field("location")
+                    .placement(p -> p
+                        .origin(geoLocation)
+                        .scale("5km")
+                        .offset("0km")
+                        .decay(0.5)
+                    )
+                )
+            )
+            .weight(10.0)
+        );
+
+        return Query.of(q -> q
+            .functionScore(fsq -> fsq
+                .query(boolQuery)
+                .functions(List.of(gaussFunction))
+                .scoreMode(FunctionScoreMode.Sum)
+                .boostMode(FunctionBoostMode.Sum)
+            )
+        );
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/store/controller/StoreController.java
+++ b/src/main/java/com/ureca/uble/domain/store/controller/StoreController.java
@@ -1,23 +1,18 @@
 package com.ureca.uble.domain.store.controller;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.ureca.uble.domain.common.dto.response.CommonResponse;
+import com.ureca.uble.domain.store.dto.response.GetGlobalSuggestionListRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreDetailRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreListRes;
 import com.ureca.uble.domain.store.dto.response.GetStoreSummaryRes;
 import com.ureca.uble.domain.store.service.StoreService;
 import com.ureca.uble.entity.enums.BenefitType;
 import com.ureca.uble.entity.enums.Season;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/stores")
@@ -102,5 +97,26 @@ public class StoreController {
         @Parameter(description = "매장 id", required = true)
         @PathVariable Long storeId) {
         return CommonResponse.success(storeService.getStoreDetail(latitude, longitude, userId, storeId));
+    }
+
+    /**
+     * (자동완성) 지도 전체 검색 자동완성
+     *
+     * @param latitude 위도
+     * @param longitude 경도
+     * @param size 사용자 정보
+     */
+    @Operation(summary = "(자동완성) 지도 전체 검색 자동완성", description = "(자동완성) 지도 전체 검색 자동완성")
+    @GetMapping("/suggestions")
+    public CommonResponse<GetGlobalSuggestionListRes> getGlobalSuggestionList(
+        @Parameter(description = "검색어", required = true)
+        @RequestParam String keyword,
+        @Parameter(description = "위도", required = true)
+        @RequestParam double latitude,
+        @Parameter(description = "경도", required = true)
+        @RequestParam double longitude,
+        @Parameter(description = "한번에 가져올 크기")
+        @RequestParam(defaultValue = "10") int size) {
+        return CommonResponse.success(storeService.getGlobalSuggestionList(keyword, latitude, longitude, size));
     }
 }

--- a/src/main/java/com/ureca/uble/domain/store/dto/response/GetGlobalSuggestionListRes.java
+++ b/src/main/java/com/ureca/uble/domain/store/dto/response/GetGlobalSuggestionListRes.java
@@ -1,0 +1,16 @@
+package com.ureca.uble.domain.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "지도 내 자동완성 결과 반환 DTO")
+public class GetGlobalSuggestionListRes {
+
+    @Schema(description = "자동완성 결과 List")
+    private List<GetGlobalSuggestionRes> suggestionList;
+}

--- a/src/main/java/com/ureca/uble/domain/store/dto/response/GetGlobalSuggestionRes.java
+++ b/src/main/java/com/ureca/uble/domain/store/dto/response/GetGlobalSuggestionRes.java
@@ -1,0 +1,36 @@
+package com.ureca.uble.domain.store.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.ureca.uble.entity.enums.SuggestionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description="지도 내 자동완성 조회 응답 DTO")
+public class GetGlobalSuggestionRes {
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    @Schema(description = "자동완성", example = "할리스")
+    private String suggestion;
+
+    @Schema(description = "카테고리", example = "BRAND")
+    private String category;
+
+    @Schema(description = "주소", example = "BRAND")
+    private String address;
+
+    @Schema(description = "자동완성 타입", example = "BRAND")
+    private SuggestionType type;
+
+    public static GetGlobalSuggestionRes of(String suggestion, String category, String address, SuggestionType type) {
+        return GetGlobalSuggestionRes.builder()
+            .suggestion(suggestion)
+            .category(category)
+            .address(address)
+            .type(type)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomLocationCoordinationDocumentRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomLocationCoordinationDocumentRepository.java
@@ -1,0 +1,10 @@
+package com.ureca.uble.domain.store.repository;
+
+import com.ureca.uble.entity.document.LocationCoordinationDocument;
+import org.springframework.data.elasticsearch.core.SearchHits;
+
+import java.util.List;
+
+public interface CustomLocationCoordinationDocumentRepository {
+    SearchHits<LocationCoordinationDocument> findCoordinationByLocation(List<String> keywordList);
+}

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomLocationCoordinationDocumentRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomLocationCoordinationDocumentRepositoryImpl.java
@@ -1,0 +1,73 @@
+package com.ureca.uble.domain.store.repository;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScore;
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import com.ureca.uble.entity.document.LocationCoordinationDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomLocationCoordinationDocumentRepositoryImpl implements CustomLocationCoordinationDocumentRepository {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Override
+    public SearchHits<LocationCoordinationDocument> findCoordinationByLocation(List<String> keywordList) {
+        // should 쿼리 생성 : 유연한 검색
+        List<Query> shouldQueries = new ArrayList<>();
+        keywordList.forEach(keyword -> {
+            shouldQueries.add(MatchQuery.of(m -> m
+                .field("name")
+                .query(keyword)
+            )._toQuery());
+        });
+
+        Query boolQuery = Query.of(q -> q
+            .bool(b -> b
+                .should(shouldQueries)
+                .minimumShouldMatch("1")
+            )
+        );
+
+        // keyword 일치 시 가중치 부여
+        List<FieldValue> fieldValues = keywordList.stream()
+            .map(FieldValue::of)
+            .toList();
+
+        List<FunctionScore> functions = new ArrayList<>();
+        functions.add(FunctionScore.of(fs -> fs
+            .filter(Query.of(q -> q
+                .terms(t -> t
+                    .field("name.raw")
+                    .terms(tt -> tt.value(fieldValues))
+                )
+            ))
+            .weight(10.0)
+        ));
+
+        // 최종 쿼리 빌드
+        FunctionScoreQuery functionScoreQuery = FunctionScoreQuery.of(f -> f
+            .query(boolQuery)
+            .functions(functions)
+        );
+
+        NativeQuery searchQuery = NativeQuery.builder()
+            .withQuery(functionScoreQuery._toQuery())
+            .withMaxResults(1)
+            .build();
+
+        // 검색 실행 및 결과 반환
+        return elasticsearchOperations.search(searchQuery, LocationCoordinationDocument.class);
+    }
+
+}

--- a/src/main/java/com/ureca/uble/domain/store/repository/LocationCoordinationDocumentRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/LocationCoordinationDocumentRepository.java
@@ -1,0 +1,7 @@
+package com.ureca.uble.domain.store.repository;
+
+import com.ureca.uble.entity.document.LocationCoordinationDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface LocationCoordinationDocumentRepository extends ElasticsearchRepository<LocationCoordinationDocument, String>, CustomLocationCoordinationDocumentRepository {
+}

--- a/src/main/java/com/ureca/uble/entity/document/LocationCoordinationDocument.java
+++ b/src/main/java/com/ureca/uble/entity/document/LocationCoordinationDocument.java
@@ -1,0 +1,25 @@
+package com.ureca.uble.entity.document;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.*;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+
+@Getter
+@Builder
+@Document(indexName = "location-coordination")
+@Setting(settingPath = "/elasticsearch/search-log-settings.json")
+public class LocationCoordinationDocument {
+    @Id
+    private String id;
+
+    @MultiField(
+        mainField = @Field(type = FieldType.Text, analyzer = "address_synonym_analyzer"),
+        otherFields = { @InnerField(suffix = "raw", type = FieldType.Keyword) }
+    )
+    private String name;
+
+    @GeoPointField
+    private GeoPoint location;
+}

--- a/src/main/resources/elasticsearch/location-coordination-settings.json
+++ b/src/main/resources/elasticsearch/location-coordination-settings.json
@@ -1,0 +1,19 @@
+{
+  "analysis": {
+    "filter": {
+      "address_synonym_filter": {
+        "type": "synonym",
+        "synonyms_path": "analysis/address-synonyms.txt"
+      }
+    },
+    "analyzer": {
+      "address_synonym_analyzer": {
+        "tokenizer": "standard",
+        "filter": [
+          "lowercase",
+          "address_synonym_filter"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #45 

## 📝작업 내용
- 지도 내 자동완성 기능을 구현하였습니다.
- 검색 결과 최적화를 위해 동의어 사전 수정 및 위치 인덱스 추가를 수행하였습니다.
- 제휴처 자동완성에 Msearch를 적용하여 쿼리 전송 횟수를 1회로 줄였습니다.
- 제휴처/지도 내 자동완성의 공통 로직을 CustomSuggestionRepository로 분리하였습니다.

## 📷스크린샷 (선택)
<img width="714" height="467" alt="image" src="https://github.com/user-attachments/assets/71a10e93-c70d-419a-93ed-9782fcc86c82" />

## 💬리뷰 요구사항(선택)
- 검색 결과 중 일부 부정확한 부분이 있어 추후 고도화 할 예정입니다.