### PR TITLE
[Fix] 매장 조회 시 개수 제한 추가

### DIFF
--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -29,18 +29,19 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
     public List<Store> findStoresInBox(double swLng, double swLat, double neLng, double neLat,
                                        Long categoryId, Long brandId, Season season, BenefitType type) {
         return jpaQueryFactory
-                .select(store).from(store)
-                .innerJoin(store.brand, brand).fetchJoin()
-                .innerJoin(brand.category, category).fetchJoin()
-                .where(
-                        Expressions.booleanTemplate(
-                                "function('ST_Intersects', {0}, function('ST_MakeEnvelope', {1}, {2}, {3}, {4}, 4326)) = TRUE",
-                                store.location,
-                                swLng, swLat, neLng, neLat
-                        ),
-                        categoryIdEq(categoryId), brandIdEq(brandId), seasonEq(season), typeEq(type)
-                )
-                .fetch();
+            .select(store).from(store)
+            .innerJoin(store.brand, brand).fetchJoin()
+            .innerJoin(brand.category, category).fetchJoin()
+            .where(
+                Expressions.booleanTemplate(
+                    "function('ST_Intersects', {0}, function('ST_MakeEnvelope', {1}, {2}, {3}, {4}, 4326)) = TRUE",
+                    store.location,
+                    swLng, swLat, neLng, neLat
+                ),
+                categoryIdEq(categoryId), brandIdEq(brandId), seasonEq(season), typeEq(type)
+            )
+            .limit(50)
+            .fetch();
     }
 
     public BooleanExpression getCondition(BenefitType type) {


### PR DESCRIPTION
## 📝작업 내용
- 매장 정보가 많아 메모리 문제가 발생하는 문제를 해결하기 위해 임시로 개수 제한을 추가하였습니다. (추후 수정예정

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)

