### PR TITLE
[Feat] 어드민 통계 조회 API 구현

### DIFF
--- a/src/main/java/com/ureca/uble/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/ureca/uble/domain/admin/controller/AdminController.java
@@ -1,9 +1,6 @@
 package com.ureca.uble.domain.admin.controller;
 
-import com.ureca.uble.domain.admin.dto.response.GetClickRankListRes;
-import com.ureca.uble.domain.admin.dto.response.GetDailySearchRankListRes;
-import com.ureca.uble.domain.admin.dto.response.GetLocalRankListRes;
-import com.ureca.uble.domain.admin.dto.response.GetUsageRankListRes;
+import com.ureca.uble.domain.admin.dto.response.*;
 import com.ureca.uble.domain.admin.service.AdminService;
 import com.ureca.uble.domain.common.dto.response.CommonResponse;
 import com.ureca.uble.entity.enums.BenefitType;
@@ -117,5 +114,27 @@ public class AdminController {
         @Parameter(description = "혜택 타입 ")
         @RequestParam(required = false) BenefitType benefitType) {
         return CommonResponse.success(adminService.getDailySearchRank(gender, ageRange, rank, benefitType));
+    }
+
+    /**
+     * (통계) 결과 미포함 검색어 순위
+     *
+     * @param gender 성별
+     * @param ageRange 나이대
+     * @param rank 사용자 등급
+     * @param benefitType 혜택 타입
+     */
+    @Operation(summary = "(통계) 결과 미포함 검색어 순위", description = "성별/나이/유저등급/혜택타입에 따른 결과 미포함 검색어 순위")
+    @GetMapping("/statistics/rank/keywords/empty-top")
+    public CommonResponse<GetEmptySearchRankListRes> getEmptySearchRank (
+        @Parameter(description = "성별")
+        @RequestParam(required = false) Gender gender,
+        @Parameter(description = "나이대 (10 단위)")
+        @RequestParam(required = false) Integer ageRange,
+        @Parameter(description = "사용자 등급 (NONE 제외)")
+        @RequestParam(required = false) Rank rank,
+        @Parameter(description = "혜택 타입 ")
+        @RequestParam(required = false) BenefitType benefitType) {
+        return CommonResponse.success(adminService.getEmptySearchRank(gender, ageRange, rank, benefitType));
     }
 }

--- a/src/main/java/com/ureca/uble/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/ureca/uble/domain/admin/controller/AdminController.java
@@ -147,7 +147,7 @@ public class AdminController {
      * @param benefitType 혜택 타입
      */
     @Operation(summary = "(통계) 상위 10개 제휴처 대상 관심사 변화 추이", description = "성별/나이/유저등급/혜택타입에 따른 관심사 변화 추이 (상위 10개 제휴처 대상)")
-    @GetMapping("/statistics/rank/asdfasdf") // TODO: 이름바꾸기
+    @GetMapping("/statistics/rank/interest-change")
     public CommonResponse<GetInterestChangeRes> getInterestChange (
         @Parameter(description = "성별")
         @RequestParam(required = false) Gender gender,

--- a/src/main/java/com/ureca/uble/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/ureca/uble/domain/admin/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.ureca.uble.domain.admin.controller;
 
 import com.ureca.uble.domain.admin.dto.response.GetClickRankListRes;
+import com.ureca.uble.domain.admin.dto.response.GetDailySearchRankListRes;
 import com.ureca.uble.domain.admin.dto.response.GetLocalRankListRes;
 import com.ureca.uble.domain.admin.dto.response.GetUsageRankListRes;
 import com.ureca.uble.domain.admin.service.AdminService;
@@ -94,5 +95,27 @@ public class AdminController {
         @Parameter(description = "혜택 타입 ")
         @RequestParam(required = false) BenefitType benefitType) {
         return CommonResponse.success(adminService.getLocalRank(gender, ageRange, rank, benefitType));
+    }
+
+    /**
+     * (통계) 일별 인기 검색어 순위
+     *
+     * @param gender 성별
+     * @param ageRange 나이대
+     * @param rank 사용자 등급
+     * @param benefitType 혜택 타입
+     */
+    @Operation(summary = "(통계) 일별 인기 검색어 순위", description = "성별/나이/유저등급/혜택타입에 따른 일별 인기 검색어 순위 (7일)")
+    @GetMapping("/statistics/rank/keywords/daily-top")
+    public CommonResponse<GetDailySearchRankListRes> getDailySearchRank (
+        @Parameter(description = "성별")
+        @RequestParam(required = false) Gender gender,
+        @Parameter(description = "나이대 (10 단위)")
+        @RequestParam(required = false) Integer ageRange,
+        @Parameter(description = "사용자 등급 (NONE 제외)")
+        @RequestParam(required = false) Rank rank,
+        @Parameter(description = "혜택 타입 ")
+        @RequestParam(required = false) BenefitType benefitType) {
+        return CommonResponse.success(adminService.getDailySearchRank(gender, ageRange, rank, benefitType));
     }
 }

--- a/src/main/java/com/ureca/uble/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/ureca/uble/domain/admin/controller/AdminController.java
@@ -137,4 +137,26 @@ public class AdminController {
         @RequestParam(required = false) BenefitType benefitType) {
         return CommonResponse.success(adminService.getEmptySearchRank(gender, ageRange, rank, benefitType));
     }
+
+    /**
+     * (통계) 관심사 변화 추이 (top 10)
+     *
+     * @param gender 성별
+     * @param ageRange 나이대
+     * @param rank 사용자 등급
+     * @param benefitType 혜택 타입
+     */
+    @Operation(summary = "(통계) 상위 10개 제휴처 대상 관심사 변화 추이", description = "성별/나이/유저등급/혜택타입에 따른 관심사 변화 추이 (상위 10개 제휴처 대상)")
+    @GetMapping("/statistics/rank/asdfasdf") // TODO: 이름바꾸기
+    public CommonResponse<GetInterestChangeRes> getInterestChange (
+        @Parameter(description = "성별")
+        @RequestParam(required = false) Gender gender,
+        @Parameter(description = "나이대 (10 단위)")
+        @RequestParam(required = false) Integer ageRange,
+        @Parameter(description = "사용자 등급 (NONE 제외)")
+        @RequestParam(required = false) Rank rank,
+        @Parameter(description = "혜택 타입 ")
+        @RequestParam(required = false) BenefitType benefitType) {
+        return CommonResponse.success(adminService.getInterestChange(gender, ageRange, rank, benefitType));
+    }
 }

--- a/src/main/java/com/ureca/uble/domain/admin/dto/response/GetDailySearchRankListRes.java
+++ b/src/main/java/com/ureca/uble/domain/admin/dto/response/GetDailySearchRankListRes.java
@@ -1,0 +1,15 @@
+package com.ureca.uble.domain.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "일별 검색어 인기 순위 반환 DTO")
+public class GetDailySearchRankListRes {
+    @Schema(description = "전체 인기 순위 리스트")
+    List<GetRankListRes> rankList;
+}

--- a/src/main/java/com/ureca/uble/domain/admin/dto/response/GetDailySearchRankListRes.java
+++ b/src/main/java/com/ureca/uble/domain/admin/dto/response/GetDailySearchRankListRes.java
@@ -11,5 +11,5 @@ import java.util.List;
 @Schema(description = "일별 검색어 인기 순위 반환 DTO")
 public class GetDailySearchRankListRes {
     @Schema(description = "전체 인기 순위 리스트")
-    List<GetRankListRes> rankList;
+    private List<GetRankListRes> rankList;
 }

--- a/src/main/java/com/ureca/uble/domain/admin/dto/response/GetEmptySearchRankListRes.java
+++ b/src/main/java/com/ureca/uble/domain/admin/dto/response/GetEmptySearchRankListRes.java
@@ -11,5 +11,5 @@ import java.util.List;
 @Schema(description = "결과 미포함 검색어 순위 반환 DTO")
 public class GetEmptySearchRankListRes {
     @Schema(description = "순위 List")
-    List<RankDetailRes> rankList;
+    private List<RankDetailRes> rankList;
 }

--- a/src/main/java/com/ureca/uble/domain/admin/dto/response/GetEmptySearchRankListRes.java
+++ b/src/main/java/com/ureca/uble/domain/admin/dto/response/GetEmptySearchRankListRes.java
@@ -1,0 +1,15 @@
+package com.ureca.uble.domain.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "결과 미포함 검색어 순위 반환 DTO")
+public class GetEmptySearchRankListRes {
+    @Schema(description = "순위 List")
+    List<RankDetailRes> rankList;
+}

--- a/src/main/java/com/ureca/uble/domain/admin/dto/response/GetInterestChangeRes.java
+++ b/src/main/java/com/ureca/uble/domain/admin/dto/response/GetInterestChangeRes.java
@@ -1,0 +1,15 @@
+package com.ureca.uble.domain.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "관심사 변화 추이 반환 DTO")
+public class GetInterestChangeRes {
+    @Schema(description = "결과 List")
+    private List<GetInterestListRes> interestRankList;
+}

--- a/src/main/java/com/ureca/uble/domain/admin/dto/response/GetInterestListRes.java
+++ b/src/main/java/com/ureca/uble/domain/admin/dto/response/GetInterestListRes.java
@@ -1,0 +1,26 @@
+package com.ureca.uble.domain.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "관심사 순위 반환 DTO")
+public class GetInterestListRes {
+    @Schema(description = "대상 일자", example = "2025-07-26")
+    private LocalDate date;
+
+    @Schema(description = "인기 순위 리스트")
+    private List<InterestDetailRes> rankList;
+
+    public static GetInterestListRes of(LocalDate date, List<InterestDetailRes> rankList) {
+        return GetInterestListRes.builder()
+            .date(date)
+            .rankList(rankList)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/admin/dto/response/GetRankListRes.java
+++ b/src/main/java/com/ureca/uble/domain/admin/dto/response/GetRankListRes.java
@@ -1,0 +1,26 @@
+package com.ureca.uble.domain.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "일별 검색어 인기 순위 반환 DTO")
+public class GetRankListRes {
+    @Schema(description = "대상 일자", example = "2025-07-26")
+    private LocalDate date;
+
+    @Schema(description = "인기 순위 리스트")
+    private List<RankDetailRes> rankList;
+
+    public static GetRankListRes of(LocalDate date, List<RankDetailRes> rankList) {
+        return GetRankListRes.builder()
+            .date(date)
+            .rankList(rankList)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/admin/dto/response/InterestDetailRes.java
+++ b/src/main/java/com/ureca/uble/domain/admin/dto/response/InterestDetailRes.java
@@ -1,0 +1,35 @@
+package com.ureca.uble.domain.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "관심사 순위 상세 정보 반환 DTO")
+public class InterestDetailRes {
+    @Schema(description = "브랜드명", example = "할리스")
+    private String name;
+
+    @Schema(description = "통합 점수", example = "100")
+    private Long totalScore;
+
+    @Schema(description = "제휴처 클릭수", example = "20")
+    private Long brandClickCount;
+
+    @Schema(description = "매장 클릭수", example = "20")
+    private Long storeClickCount;
+
+    @Schema(description = "사용량", example = "20")
+    private Long usageCount;
+
+    public static InterestDetailRes of(String name, Long totalScore, Long brandClickCount, Long storeClickCount, Long usageCount) {
+        return InterestDetailRes.builder()
+            .name(name)
+            .totalScore(totalScore)
+            .brandClickCount(brandClickCount)
+            .storeClickCount(storeClickCount)
+            .usageCount(usageCount)
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ureca/uble/domain/admin/service/AdminService.java
@@ -92,4 +92,18 @@ public class AdminService {
 
         return new GetDailySearchRankListRes(rankList);
     }
+
+    /**
+     * (통계) 결과 미포함 검색어 순위
+     */
+    public GetEmptySearchRankListRes getEmptySearchRank(Gender gender, Integer ageRange, Rank rank, BenefitType benefitType) {
+        ElasticsearchAggregations rankResult = searchLogDocumentRepository.getEmptySearchRankByFiltering(gender, ageRange, rank, benefitType);
+
+        List<RankDetailRes> rankList = rankResult.aggregationsAsMap()
+            .get("empty_top_keywords").aggregation().getAggregate().sterms().buckets().array().stream()
+            .map(b -> RankDetailRes.of(b.key().stringValue(), b.docCount()))
+            .toList();
+
+        return new GetEmptySearchRankListRes(rankList);
+    }
 }

--- a/src/main/java/com/ureca/uble/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ureca/uble/domain/admin/service/AdminService.java
@@ -2,19 +2,23 @@ package com.ureca.uble.domain.admin.service;
 
 import com.ureca.uble.domain.admin.dto.response.*;
 import com.ureca.uble.domain.brand.repository.BrandClickLogDocumentRepository;
+import com.ureca.uble.domain.common.repository.CustomSuggestionRepository;
 import com.ureca.uble.domain.store.repository.SearchLogDocumentRepository;
 import com.ureca.uble.domain.users.repository.UsageHistoryDocumentRepository;
-import com.ureca.uble.entity.enums.BenefitType;
-import com.ureca.uble.entity.enums.Gender;
-import com.ureca.uble.entity.enums.Rank;
-import com.ureca.uble.entity.enums.RankTarget;
+import com.ureca.uble.entity.enums.*;
+import com.ureca.uble.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.*;
 
+import static com.ureca.uble.domain.common.exception.CommonErrorCode.ELASTIC_INTERNAL_ERROR;
+import static com.ureca.uble.entity.enums.InterestType.*;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminService {
@@ -22,6 +26,7 @@ public class AdminService {
     private final UsageHistoryDocumentRepository usageHistoryDocumentRepository;
     private final BrandClickLogDocumentRepository brandClickLogDocumentRepository;
     private final SearchLogDocumentRepository searchLogDocumentRepository;
+    private final CustomSuggestionRepository customSuggestionRepository;
 
     /**
      * (통계) 제휴처/카테고리 이용 순위
@@ -105,5 +110,84 @@ public class AdminService {
             .toList();
 
         return new GetEmptySearchRankListRes(rankList);
+    }
+
+    /**
+     * (통계) 관심사 변화 추이
+     */
+    public GetInterestChangeRes getInterestChange(Gender gender, Integer ageRange, Rank rank, BenefitType benefitType) {
+        // 이번 달 상위 10개 제휴처 조회
+        ElasticsearchAggregations rankResult = customSuggestionRepository.getTopInterestBrandByFiltering(gender, ageRange, rank, benefitType);
+
+        List<String> brandNameList = rankResult.aggregationsAsMap()
+            .get("top_brands").aggregation().getAggregate().sterms().buckets().array().stream()
+            .map(b -> b.key().stringValue()).toList();
+
+        // 제휴처 별 각 기준 count 조회
+        GetInterestChangeRes result;
+        try {
+            ElasticsearchAggregations brandResult = customSuggestionRepository.getCountsByFiltering(BRAND_CLICK, brandNameList, gender, ageRange, rank, benefitType);
+            ElasticsearchAggregations storeResult = customSuggestionRepository.getCountsByFiltering(STORE_CLICK, brandNameList, gender, ageRange, rank, benefitType);
+            ElasticsearchAggregations usageResult = customSuggestionRepository.getCountsByFiltering(USAGE, brandNameList, gender, ageRange, rank, benefitType);
+            result = parseInterestChangeRes(brandResult, storeResult, usageResult);
+        } catch (Exception e) {
+            throw new GlobalException(ELASTIC_INTERNAL_ERROR);
+        }
+        return result;
+    }
+
+    public GetInterestChangeRes parseInterestChangeRes(ElasticsearchAggregations brandResult, ElasticsearchAggregations storeResult, ElasticsearchAggregations usageResult) {
+        List<GetInterestListRes> resultList = new ArrayList<>();
+        resultList.addAll(parseGetInterestListRes(brandResult, BRAND_CLICK));
+        resultList.addAll(parseGetInterestListRes(storeResult, STORE_CLICK));
+        resultList.addAll(parseGetInterestListRes(usageResult, USAGE));
+
+        return new GetInterestChangeRes(mergeAndSumByDateAndBrand(resultList));
+    }
+
+    private List<GetInterestListRes> parseGetInterestListRes(ElasticsearchAggregations result, InterestType type) {
+        return result.aggregationsAsMap()
+            .get("monthly_count").aggregation().getAggregate().filter().aggregations()
+            .get("count_info").dateHistogram().buckets().array().stream()
+            .map(bucket -> GetInterestListRes.of(
+                LocalDate.parse(bucket.keyAsString() + "-01"),
+                bucket.aggregations()
+                    .get("rank").sterms()
+                    .buckets().array().stream()
+                    .map(b -> switch (type) {
+                        case BRAND_CLICK -> InterestDetailRes.of(b.key().stringValue(), b.docCount(), b.docCount(), 0L, 0L);
+                        case STORE_CLICK -> InterestDetailRes.of(b.key().stringValue(), b.docCount(), 0L,  b.docCount(), 0L);
+                        case USAGE -> InterestDetailRes.of(b.key().stringValue(), b.docCount() * 2, 0L, 0L, b.docCount());
+                    })
+                    .toList()
+            ))
+            .toList();
+    }
+
+    public List<GetInterestListRes> mergeAndSumByDateAndBrand(List<GetInterestListRes> resultList) {
+        Map<LocalDate, Map<String, InterestDetailRes>> grouped = new HashMap<>();
+
+        // date 기반 그룹화
+        for (GetInterestListRes res : resultList) {
+            grouped.computeIfAbsent(res.getDate(), d -> new HashMap<>());
+
+            // brandName 기반 그룹화
+            for (InterestDetailRes detail : res.getRankList()) {
+                Map<String, InterestDetailRes> brandMap = grouped.get(res.getDate());
+                brandMap.merge(detail.getName(), detail, (r1, r2) ->
+                    InterestDetailRes.of(
+                        r1.getName(),
+                        r1.getTotalScore() + r2.getTotalScore(),
+                        r1.getBrandClickCount() + r2.getBrandClickCount(),
+                        r1.getStoreClickCount() + r2.getStoreClickCount(),
+                        r1.getUsageCount() + r2.getUsageCount()
+                    )
+                );
+            }
+        }
+
+        return grouped.entrySet().stream()
+            .map(e -> GetInterestListRes.of(e.getKey(), new ArrayList<>(e.getValue().values())))
+            .sorted(Comparator.comparing(GetInterestListRes::getDate)).toList();
     }
 }

--- a/src/main/java/com/ureca/uble/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ureca/uble/domain/admin/service/AdminService.java
@@ -124,16 +124,15 @@ public class AdminService {
             .map(b -> b.key().stringValue()).toList();
 
         // 제휴처 별 각 기준 count 조회
-        GetInterestChangeRes result;
+        ElasticsearchAggregations brandResult, storeResult, usageResult;
         try {
-            ElasticsearchAggregations brandResult = customSuggestionRepository.getCountsByFiltering(BRAND_CLICK, brandNameList, gender, ageRange, rank, benefitType);
-            ElasticsearchAggregations storeResult = customSuggestionRepository.getCountsByFiltering(STORE_CLICK, brandNameList, gender, ageRange, rank, benefitType);
-            ElasticsearchAggregations usageResult = customSuggestionRepository.getCountsByFiltering(USAGE, brandNameList, gender, ageRange, rank, benefitType);
-            result = parseInterestChangeRes(brandResult, storeResult, usageResult);
+            brandResult = customSuggestionRepository.getCountsByFiltering(BRAND_CLICK, brandNameList, gender, ageRange, rank, benefitType);
+            storeResult = customSuggestionRepository.getCountsByFiltering(STORE_CLICK, brandNameList, gender, ageRange, rank, benefitType);
+            usageResult = customSuggestionRepository.getCountsByFiltering(USAGE, brandNameList, gender, ageRange, rank, benefitType);
         } catch (Exception e) {
             throw new GlobalException(ELASTIC_INTERNAL_ERROR);
         }
-        return result;
+        return parseInterestChangeRes(brandResult, storeResult, usageResult);
     }
 
     public GetInterestChangeRes parseInterestChangeRes(ElasticsearchAggregations brandResult, ElasticsearchAggregations storeResult, ElasticsearchAggregations usageResult) {

--- a/src/main/java/com/ureca/uble/domain/common/repository/CustomSuggestionRepository.java
+++ b/src/main/java/com/ureca/uble/domain/common/repository/CustomSuggestionRepository.java
@@ -1,11 +1,29 @@
 package com.ureca.uble.domain.common.repository;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.GeoLocation;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.CalendarInterval;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
 import co.elastic.clients.elasticsearch.core.MsearchRequest;
 import co.elastic.clients.elasticsearch.core.MsearchResponse;
+import co.elastic.clients.util.NamedValue;
+import com.ureca.uble.domain.common.util.SearchFilterUtils;
+import com.ureca.uble.entity.document.BrandClickLogDocument;
+import com.ureca.uble.entity.document.StoreClickLogDocument;
+import com.ureca.uble.entity.document.UsageHistoryDocument;
+import com.ureca.uble.entity.enums.BenefitType;
+import com.ureca.uble.entity.enums.Gender;
+import com.ureca.uble.entity.enums.InterestType;
+import com.ureca.uble.entity.enums.Rank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.IndexBoost;
 import org.springframework.stereotype.Repository;
 
 import java.io.IOException;
@@ -17,6 +35,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class CustomSuggestionRepository {
 
+    private final ElasticsearchOperations elasticsearchOperations;
     private final ElasticsearchClient elasticsearchClient;
 
     /**
@@ -71,6 +90,115 @@ public class CustomSuggestionRepository {
             )
             .build();
         return elasticsearchClient.msearch(request, Map.class);
+    }
+
+    /**
+     * 관심도 상위 10개 제휴처 조회
+     */
+    public ElasticsearchAggregations getTopInterestBrandByFiltering(Gender gender, Integer ageRange, Rank rank, BenefitType benefitType) {
+        // filter 설정
+        List<Query> filters = SearchFilterUtils.getAdminStatisticFilters(gender, ageRange, rank, benefitType);
+
+        filters.add(DateRangeQuery.of(r -> r
+            .field("createdAt")
+            .gte("now/M")
+            .lte("now")
+        )._toRangeQuery()._toQuery());
+
+        // 통계 쿼리 작성
+        Aggregation aggregation = Aggregation.of(a -> a
+            .terms(t -> t
+                .field("brandName")
+                .size(10)
+                .order(List.of(NamedValue.of("_count", SortOrder.Desc)))
+            )
+        );
+
+        // Index 가중치 설정
+        List<IndexBoost> boosts = List.of(
+            new IndexBoost("usage-history-log", 2.0f),
+            new IndexBoost("brand-click-log", 1.0f),
+            new IndexBoost("store-click-log", 1.0f)
+        );
+
+        // 최종 쿼리 작성
+        NativeQuery query = NativeQuery.builder()
+            .withQuery(q -> q.bool(b -> b.filter(filters)))
+            .withAggregation("top_brands", aggregation)
+            .withIndicesBoost(boosts)
+            .withMaxResults(0)
+            .withIndicesBoost()
+            .build();
+
+        return (ElasticsearchAggregations) elasticsearchOperations
+            .search(query, Map.class, IndexCoordinates.of("brand-click-log", "store-click-log", "usage-history-log"))
+            .getAggregations();
+    }
+
+    /**
+     * 제휴처 별 클릭 및 사용량 조회
+     */
+    public ElasticsearchAggregations getCountsByFiltering(InterestType type, List<String> brandNameList, Gender gender, Integer ageRange, Rank rank, BenefitType benefitType) {
+        List<Query> filters = SearchFilterUtils.getAdminStatisticFilters(gender, ageRange, rank, benefitType);
+
+        filters.add(DateRangeQuery.of(r -> r
+            .field("createdAt")
+            .gte("now-6M/M")
+            .lte("now/M")
+        )._toRangeQuery()._toQuery());
+
+        filters.add(TermsQuery.of(t -> t
+            .field("brandName")
+            .terms(v -> v.value(
+                brandNameList.stream().map(FieldValue::of).toList()
+            ))
+        )._toQuery());
+
+        // 통계 쿼리 작성
+        Aggregation aggregation = Aggregation.of(a -> a
+            .filter(f -> f
+                .bool(b -> b.filter(filters))
+            )
+            .aggregations("count_info", da -> da
+                .dateHistogram(dh -> dh
+                    .field("createdAt")
+                    .calendarInterval(CalendarInterval.Month)
+                    .format("yyyy-MM")
+                    .order(List.of(NamedValue.of("_key", SortOrder.Asc)))
+                )
+                .aggregations("rank", b -> b
+                    .terms(t -> t
+                        .field("brandName")
+                        .order(List.of(NamedValue.of("_count", SortOrder.Desc)))
+                    )
+                )
+            )
+        );
+
+        // Index 가중치 설정
+        List<IndexBoost> boosts = List.of(
+            new IndexBoost("usage-history-log", 2.0f),
+            new IndexBoost("brand-click-log", 1.0f),
+            new IndexBoost("store-click-log", 1.0f)
+        );
+
+        // 최종 쿼리 생성
+        NativeQuery query = NativeQuery.builder()
+            .withIndicesBoost(boosts)
+            .withQuery(q -> q.bool(b -> b.filter(filters)))
+            .withAggregation("monthly_count", aggregation)
+            .withMaxResults(0)
+            .build();
+
+        Class<?> classType = switch (type) {
+            case BRAND_CLICK -> BrandClickLogDocument.class;
+            case STORE_CLICK -> StoreClickLogDocument.class;
+            case USAGE -> UsageHistoryDocument.class;
+        };
+
+        return (ElasticsearchAggregations) elasticsearchOperations
+            .search(query, classType)
+            .getAggregations();
     }
 
     private Query getCategoryQuery(String keyword) {

--- a/src/main/java/com/ureca/uble/domain/common/repository/CustomSuggestionRepository.java
+++ b/src/main/java/com/ureca/uble/domain/common/repository/CustomSuggestionRepository.java
@@ -127,7 +127,6 @@ public class CustomSuggestionRepository {
             .withAggregation("top_brands", aggregation)
             .withIndicesBoost(boosts)
             .withMaxResults(0)
-            .withIndicesBoost()
             .build();
 
         return (ElasticsearchAggregations) elasticsearchOperations

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomSearchLogDocumentRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomSearchLogDocumentRepository.java
@@ -1,0 +1,10 @@
+package com.ureca.uble.domain.store.repository;
+
+import com.ureca.uble.entity.enums.BenefitType;
+import com.ureca.uble.entity.enums.Gender;
+import com.ureca.uble.entity.enums.Rank;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+
+public interface CustomSearchLogDocumentRepository {
+    ElasticsearchAggregations getPopularSearchRankByFiltering(Gender gender, Integer ageRange, Rank rank, BenefitType benefitType);
+}

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomSearchLogDocumentRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomSearchLogDocumentRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregatio
 
 public interface CustomSearchLogDocumentRepository {
     ElasticsearchAggregations getPopularSearchRankByFiltering(Gender gender, Integer ageRange, Rank rank, BenefitType benefitType);
+
+    ElasticsearchAggregations getEmptySearchRankByFiltering(Gender gender, Integer ageRange, Rank rank, BenefitType benefitType);
 }

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomSearchLogDocumentRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomSearchLogDocumentRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.ureca.uble.domain.store.repository;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.CalendarInterval;
+import co.elastic.clients.elasticsearch._types.query_dsl.DateRangeQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.util.NamedValue;
+import com.ureca.uble.domain.common.util.SearchFilterUtils;
+import com.ureca.uble.entity.document.SearchLogDocument;
+import com.ureca.uble.entity.enums.BenefitType;
+import com.ureca.uble.entity.enums.Gender;
+import com.ureca.uble.entity.enums.Rank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomSearchLogDocumentRepositoryImpl implements CustomSearchLogDocumentRepository {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Override
+    public ElasticsearchAggregations getPopularSearchRankByFiltering(Gender gender, Integer ageRange, Rank rank, BenefitType benefitType) {
+        // filter 설정
+        List<Query> filters = SearchFilterUtils.getAdminStatisticFilters(gender, ageRange, rank, benefitType);
+        filters.add(DateRangeQuery.of(r -> r
+            .field("createdAt")
+            .gte("now-6d/d")
+            .lte("now/d")
+        )._toRangeQuery()._toQuery());
+
+        // 통계 쿼리
+        Aggregation aggregation = Aggregation.of(a -> a
+            .filter(f -> f
+                .bool(b -> b.filter(filters))
+            )
+            .aggregations("daily_top10", da -> da
+                .dateHistogram(dh -> dh
+                    .field("createdAt")
+                    .calendarInterval(CalendarInterval.Day)
+                    .format("yyyy-MM-dd")
+                    .order(List.of(NamedValue.of("_key", SortOrder.Desc)))
+                )
+                .aggregations("rank", ta -> ta
+                    .terms(t -> t
+                        .field("searchKeyword.raw")
+                        .size(10)
+                        .order(List.of(NamedValue.of("_count", SortOrder.Desc)))
+                    )
+                )
+            )
+        );
+
+        // 최종 쿼리 생성
+        NativeQuery query = NativeQuery.builder()
+            .withAggregation("daily_top_keywords", aggregation)
+            .withMaxResults(0)
+            .build();
+
+        return (ElasticsearchAggregations) elasticsearchOperations.search(query, SearchLogDocument.class).getAggregations();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/store/repository/SearchLogDocumentRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/SearchLogDocumentRepository.java
@@ -3,5 +3,5 @@ package com.ureca.uble.domain.store.repository;
 import com.ureca.uble.entity.document.SearchLogDocument;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface SearchLogDocumentRepository extends ElasticsearchRepository<SearchLogDocument, String> {
+public interface SearchLogDocumentRepository extends ElasticsearchRepository<SearchLogDocument, String>, CustomSearchLogDocumentRepository {
 }

--- a/src/main/java/com/ureca/uble/entity/enums/InterestType.java
+++ b/src/main/java/com/ureca/uble/entity/enums/InterestType.java
@@ -1,0 +1,7 @@
+package com.ureca.uble.entity.enums;
+
+public enum InterestType {
+    BRAND_CLICK,
+    STORE_CLICK,
+    USAGE
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #84 

## 📝작업 내용
- 어드민 통계 API를 구현하였습니다.
    - 인기 검색어 순위 : 최근 7일간 각각의 탑 10을 반환
    - 결과 미포함 인기 검색어 순위 : 1개월 통합 탑 10을 반환
    - 제휴처별 관심도 변화율 : 최근 6개월간 각 월의 점수 탑 10을 반환

## 📷스크린샷 (선택)
<img width="547" height="463" alt="image" src="https://github.com/user-attachments/assets/d9fe9908-7135-48df-afa6-d6a6005fd2d9" />

## 💬리뷰 요구사항(선택)
- 결과 파싱에 어려움이 있어 현재 ES 호출 횟수가 많은 상태입니다. 추후 MSearch 적용하여 수정할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자 통계 페이지에 일별 인기 검색어 순위, 검색 결과가 없는 검색어 순위, 관심사 변화 추이(상위 10개 파트너 기준) 조회 API가 추가되었습니다.
  * 각 통계 API는 성별, 연령대, 등급, 혜택 유형별 필터링을 지원합니다.

* **버그 수정**
  * 해당 없음

* **문서화**
  * Swagger를 통한 API 명세 및 파라미터 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->