### PR TITLE
[Fix] 제휴처 전체 조회 API 북마크여부 조회 로직 수정

### DIFF
--- a/src/main/java/com/ureca/uble/domain/brand/controller/BrandController.java
+++ b/src/main/java/com/ureca/uble/domain/brand/controller/BrandController.java
@@ -39,7 +39,7 @@ public class BrandController {
 		@RequestParam(required=false) Long categoryId,
 		@Parameter(description = "필터링할 계절", example = "ETC")
 		@RequestParam(required=false) Season season,
-		@Parameter(description = "필터링할 타입 : VIP 또는 LOCAL", example = "VIP")
+		@Parameter(description = "필터링할 타입 : VIP 또는 LOCAL 또는 NORMAL", example = "VIP")
 		@RequestParam(required=false) BenefitType type,
 		@Parameter(description = "마지막 제휴처 ID")
 		@RequestParam(required = false) Long lastBrandId,

--- a/src/main/java/com/ureca/uble/domain/brand/dto/response/BrandListRes.java
+++ b/src/main/java/com/ureca/uble/domain/brand/dto/response/BrandListRes.java
@@ -1,10 +1,10 @@
 package com.ureca.uble.domain.brand.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ureca.uble.entity.Brand;
 import com.ureca.uble.entity.document.BrandNoriDocument;
 import com.ureca.uble.entity.enums.Rank;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,11 +39,7 @@ public class BrandListRes {
 	@JsonProperty("isBookmarked")
 	private boolean bookmarked;
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
-	@Schema(description = "북마크 ID", example = "36")
-	private Long bookmarkId;
-
-	public static BrandListRes of(Brand brand, boolean isBookmarked, Long bookmarkId, boolean isVIPcock, Rank minRank) {
+	public static BrandListRes of(Brand brand, boolean isBookmarked, boolean isVIPcock, Rank minRank) {
 		return BrandListRes.builder()
 			.brandId(brand.getId())
 			.name(brand.getName())
@@ -53,11 +49,10 @@ public class BrandListRes {
 			.minRank(minRank.toString())
 			.imgUrl(brand.getImageUrl())
 			.bookmarked(isBookmarked)
-			.bookmarkId(bookmarkId)
 			.build();
 	}
 
-	public static BrandListRes of(BrandNoriDocument brand, boolean isBookmarked, Long bookmarkId) {
+	public static BrandListRes of(BrandNoriDocument brand, boolean isBookmarked) {
 		return BrandListRes.builder()
 			.brandId(brand.getBrandId())
 			.name(brand.getBrandName())
@@ -67,7 +62,6 @@ public class BrandListRes {
 			.minRank(brand.getMinRank())
 			.imgUrl(brand.getImageUrl())
 			.bookmarked(isBookmarked)
-			.bookmarkId(bookmarkId)
 			.build();
 	}
 }

--- a/src/test/java/com/ureca/uble/domain/brand/service/BrandServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/brand/service/BrandServiceTest.java
@@ -108,6 +108,7 @@ public class BrandServiceTest {
 		when(brand1.getMinRank()).thenReturn(mockMinRank);
 		when(brand1.getDescription()).thenReturn("브랜드1 설명");
 		when(brand1.getImageUrl()).thenReturn("https://image1.com");
+		when(brand1.isVIPcock()).thenReturn(false);
 
 		// 브랜드 2 mock
 		Brand brand2 = mock(Brand.class);
@@ -117,13 +118,14 @@ public class BrandServiceTest {
 		when(brand2.getMinRank()).thenReturn(mockMinRank);
 		when(brand2.getDescription()).thenReturn("브랜드2 설명");
 		when(brand2.getImageUrl()).thenReturn("https://image2.com");
+		when(brand2.isVIPcock()).thenReturn(true);
 
 		List<Brand> mockBrands = List.of(brand1, brand2);
 
 		when(brandRepository.findWithFilterAndCursor(null, null, null, lastBrandId, size + 1))
 			.thenReturn(mockBrands);
-		when(bookmarkRepository.findByUserIdAndBrandId(eq(userId), anyLong()))
-			.thenReturn(Optional.empty());
+		when(bookmarkRepository.findAllByUser(userId))
+			.thenReturn(List.of(2L));
 
 		// when
 		CursorPageRes<BrandListRes> result = brandService.getBrandList(userId, null, null, null, lastBrandId, size);
@@ -137,11 +139,13 @@ public class BrandServiceTest {
 		assertThat(res1.getBrandId()).isEqualTo(1L);
 		assertThat(res1.getImgUrl()).isEqualTo("https://image1.com");
 		assertThat(res1.isBookmarked()).isFalse();
+		assertThat(res1.isVipcock()).isFalse();
 
 		BrandListRes res2 = result.getContent().get(1);
 		assertThat(res2.getBrandId()).isEqualTo(2L);
 		assertThat(res2.getImgUrl()).isEqualTo("https://image2.com");
-		assertThat(res2.isBookmarked()).isFalse();
+		assertThat(res2.isBookmarked()).isTrue();
+		assertThat(res2.isVipcock()).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> #123 

## 📝작업 내용

> 북마크여부 조회 시 쿼리가 N+1번 발생하는 문제를 해결했습니다.
또한, DTO에서 bookmardId를 제거하고 관련 서비스 로직을 수정하였습니다.

## 📷스크린샷 (선택)

> 
<img width="1212" height="496" alt="image" src="https://github.com/user-attachments/assets/09f43748-1fc3-4e87-a63c-d5154e037aeb" />


## 💬리뷰 요구사항(선택)

> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 브랜드 목록 조회 API의 `type` 파라미터 설명에 "NORMAL" 옵션이 추가되었습니다.

* **버그 수정**
  * 브랜드 목록 응답에서 더 이상 `bookmarkId` 필드가 포함되지 않습니다.

* **성능 개선**
  * 브랜드 즐겨찾기 여부 확인이 최적화되어, 목록 조회 시 성능이 향상되었습니다.

* **테스트**
  * 즐겨찾기 및 VIP 여부 관련 테스트가 실제 동작에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->