### PR TITLE
[Chore] 배포 서버 CD script 수정

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -28,7 +28,18 @@ jobs:
       run: |
         mkdir -p src/main/resources
         echo "${{ secrets.APPLICATION_YML_RELEASE }}" > ./src/main/resources/application.yml
+        
+    # logback 설정
+    - name: logback-spring.xml 파일 설정
+      run: |
+        mkdir -p src/main/resources
+        echo "${{ secrets.LOGBACK_SPRING_XML }}" > ./src/main/resources/logback-spring.xml
 
+    # filebeat 설정
+    - name: filebeat.yml 파일 설정
+      run: |
+        echo "${{ secrets.FILEBEAT_YML }}" > ./filebeat.yml
+        
     # Gradle 환경 설치
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
@@ -58,9 +69,9 @@ jobs:
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         script_stop: true
         script: |
-          # 모든 컨테이너 중지 및 제거 (컨테이너가 있는 경우)
-          sudo docker stop $(docker ps -a -q) || true
-          sudo docker rm -fv $(docker ps -aq) || true
+          # Spring 컨테이너 중지 및 제거 (컨테이너가 있는 경우)
+          sudo docker stop uble-main || true
+          sudo docker rm -fv uble-main || true
 
           # 이전 이미지 삭제
           sudo docker image rm ${{ secrets.DOCKER_USERNAME }}/uble-main:latest || true
@@ -69,8 +80,7 @@ jobs:
           sudo docker pull ${{ secrets.DOCKER_USERNAME }}/uble-main:latest
         
           # Docker 컨테이너 실행
-          sudo docker run -d -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/uble-main:latest
+          sudo docker run -d -p 8080:8080 --name uble-main ${{ secrets.DOCKER_USERNAME }}/uble-main:latest
         
           # 불필요한 Docker 이미지 정리
           sudo docker image prune -f
-      


### PR DESCRIPTION
## #️⃣연관된 이슈

> #131

## 📝작업 내용
- 배포 서버의 CD 스크립트를 수정하였습니다.
- 로깅을 위한 환경변수를 추가하였습니다.
- 컨테이너 삭제/pull 시 특정 이름을 가진 컨테이너를 대상으로 하도록 수정하였습니다.

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 빌드 전에 비밀 정보를 활용하여 구성 파일(`logback-spring.xml`, `filebeat.yml`)을 자동으로 생성하도록 워크플로우가 개선되었습니다.
  * 배포 시 Docker 컨테이너 관리가 전체 컨테이너에서 특정 컨테이너(`uble-main`)로 한정되어 더욱 안전하게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->