### PR TITLE
[Feat] 가장 가까운 제휴처 바로가기 API 구현

### DIFF
--- a/src/main/java/com/ureca/uble/domain/brand/controller/BrandController.java
+++ b/src/main/java/com/ureca/uble/domain/brand/controller/BrandController.java
@@ -96,4 +96,23 @@ public class BrandController {
 			@RequestParam(defaultValue = "20") int size) {
 		return CommonResponse.success(brandService.getOfflineBrands(lastBrandId, size));
 	}
+
+	/**
+	 * 가장 가까운 제휴처 매장 위경도 조회
+	 *
+	 * @param latitude 위도
+	 * @param longitude 경도
+	 * @param brandId 제휴처 id
+	 */
+	@Operation(summary = "가장 가까운 제휴처 매장 위경도 조회", description = "가장 가까운 제휴처 매장 위경도 조회")
+	@GetMapping("/{brandId}/stores/nearest")
+	public CommonResponse<GetNearestStoreRes> getNearestStoreCoordination(
+		@Parameter(description = "위도", required = true)
+		@RequestParam double latitude,
+		@Parameter(description = "경도", required = true)
+		@RequestParam double longitude,
+		@Parameter(description = "제휴처 id", required = true)
+		@PathVariable Long brandId) {
+		return CommonResponse.success(brandService.getNearestStoreCoordination(latitude, longitude, brandId));
+	}
 }

--- a/src/main/java/com/ureca/uble/domain/brand/dto/response/BrandDetailRes.java
+++ b/src/main/java/com/ureca/uble/domain/brand/dto/response/BrandDetailRes.java
@@ -1,15 +1,14 @@
 package com.ureca.uble.domain.brand.dto.response;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ureca.uble.entity.Brand;
 import com.ureca.uble.entity.enums.Season;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -36,6 +35,9 @@ public class BrandDetailRes {
 	@Schema(description = "카테고리", example = "푸드")
 	private String categoryName;
 
+	@Schema(description = "온라인 여부", example = "true")
+	private boolean isOnline;
+
 	@Schema(description = "북마크 여부", example = "true")
 	@JsonProperty("isBookmarked")
 	private boolean bookmarked;
@@ -60,11 +62,11 @@ public class BrandDetailRes {
 			.imgUrl(brand.getImageUrl())
 			.season(brand.getSeason())
 			.categoryName(brand.getCategory().getName())
+			.isOnline(brand.getIsOnline())
 			.bookmarked(isBookmarked)
 			.bookmarkId(bookmarkId)
 			.vipcock(isVIPcock)
 			.benefits(benefits)
 			.build();
 	}
-
 }

--- a/src/main/java/com/ureca/uble/domain/brand/dto/response/GetNearestStoreRes.java
+++ b/src/main/java/com/ureca/uble/domain/brand/dto/response/GetNearestStoreRes.java
@@ -1,0 +1,24 @@
+package com.ureca.uble.domain.brand.dto.response;
+
+import com.ureca.uble.entity.Store;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "가장 가까운 제휴처 매장 반환 API")
+public class GetNearestStoreRes {
+    @Schema(description = "위도", example = "37.123")
+    private Double latitude;
+
+    @Schema(description = "경도", example = "127.123")
+    private Double longitude;
+
+    public static GetNearestStoreRes from(Store store) {
+        return GetNearestStoreRes.builder()
+            .latitude(store.getLocation().getY())
+            .longitude(store.getLocation().getX())
+            .build();
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/brand/exception/BrandErrorCode.java
+++ b/src/main/java/com/ureca/uble/domain/brand/exception/BrandErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum BrandErrorCode implements ResultCode {
     BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, 4000, "제휴처를 찾을 수 없습니다."),
     BENEFIT_NOT_FOUND(HttpStatus.NOT_FOUND, 4001, "혜택 정보를 찾을 수 없습니다."),
+    BRAND_NOT_OFFLINE(HttpStatus.NOT_FOUND, 4002, "오프라인 매장 정보를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepository.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepository.java
@@ -13,4 +13,6 @@ public interface CustomStoreRepository {
     List<Store> findClusterRepresentatives(double swLng, double swLat, double neLng, double neLat,
                                            Long categoryId, Long brandId, Season season, BenefitType type,
                                            double gridSize);
+
+    Store findNearestByBrandId(Long brandId, Double latitude, Double longitude);
 }

--- a/src/main/java/com/ureca/uble/entity/Store.java
+++ b/src/main/java/com/ureca/uble/entity/Store.java
@@ -28,7 +28,7 @@ public class Store extends BaseEntity {
     @Column(name = "phone_number")
     private String phoneNumber;
 
-    @Column(columnDefinition = "geography(Point,4326)")
+    @Column(columnDefinition = "geometry(Point,4326)")
     private Point location;
 
     @Column(name = "visit_count", nullable = false)

--- a/src/test/java/com/ureca/uble/domain/brand/service/BrandServiceTest.java
+++ b/src/test/java/com/ureca/uble/domain/brand/service/BrandServiceTest.java
@@ -3,21 +3,27 @@ package com.ureca.uble.domain.brand.service;
 import com.ureca.uble.domain.bookmark.repository.BookmarkRepository;
 import com.ureca.uble.domain.brand.dto.response.BrandDetailRes;
 import com.ureca.uble.domain.brand.dto.response.BrandListRes;
+import com.ureca.uble.domain.brand.dto.response.GetNearestStoreRes;
 import com.ureca.uble.domain.brand.dto.response.OfflineBrandRes;
 import com.ureca.uble.domain.brand.repository.BrandClickLogDocumentRepository;
 import com.ureca.uble.domain.brand.repository.BrandRepository;
 import com.ureca.uble.domain.common.dto.response.CursorPageRes;
+import com.ureca.uble.domain.store.repository.StoreRepository;
 import com.ureca.uble.domain.users.repository.UserRepository;
 import com.ureca.uble.entity.Brand;
 import com.ureca.uble.entity.Category;
+import com.ureca.uble.entity.Store;
 import com.ureca.uble.entity.User;
 import com.ureca.uble.entity.document.BrandClickLogDocument;
 import com.ureca.uble.entity.enums.Gender;
 import com.ureca.uble.entity.enums.Rank;
 import com.ureca.uble.entity.enums.Season;
+import com.ureca.uble.global.exception.GlobalException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,6 +33,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +42,9 @@ public class BrandServiceTest {
 
 	@Mock
 	private BrandRepository brandRepository;
+
+	@Mock
+	private StoreRepository storeRepository;
 
 	@Mock
 	private BookmarkRepository bookmarkRepository;
@@ -68,6 +79,7 @@ public class BrandServiceTest {
 		when(mockBrand.getImageUrl()).thenReturn("https://image.com");
 		when(mockBrand.getSeason()).thenReturn(Season.SPRING);
 		when(mockBrand.getCategory()).thenReturn(mockCategory);
+		when(mockBrand.getIsOnline()).thenReturn(false);
 		when(mockBrand.isVIPcock()).thenReturn(false);
 
 		when(mockBrand.getBenefits()).thenReturn(List.of());
@@ -187,5 +199,72 @@ public class BrandServiceTest {
 						tuple(52L, "투썸플레이스", "https://.../twosome.png")
 				);
 		verify(brandRepository).findOfflineAfterCursor(lastBrandId, size + 1);
+	}
+
+	@Test
+	@DisplayName("가장 가까운 제휴처의 위경도를 반환한다.")
+	void getNearestBrandSuccess() {
+		// given
+		Long brandId = 1L;
+		Double latitude = 37.123;
+		Double longitude = 127.123;
+		GeometryFactory geometryFactory = new GeometryFactory();
+
+		Brand mockBrand = mock(Brand.class);
+		Store mockStore = mock(Store.class);
+
+		when(brandRepository.findById(brandId)).thenReturn(Optional.ofNullable(mockBrand));
+		when(storeRepository.findNearestByBrandId(brandId, latitude, longitude)).thenReturn(mockStore);
+		when(mockStore.getLocation()).thenReturn(geometryFactory.createPoint(new Coordinate(longitude, latitude)));
+
+		// when
+		GetNearestStoreRes res = brandService.getNearestStoreCoordination(latitude, longitude, brandId);
+
+		// then
+		assertThat(res.getLatitude()).isEqualTo(latitude);
+		assertThat(res.getLongitude()).isEqualTo(longitude);
+	}
+
+	@Test
+	@DisplayName("brandId가 유효하지 않을 경우 에러가 발생한다.")
+	void getNearestBrandNotExist() {
+		// given
+		Long brandId = 1L;
+		Double latitude = 37.123;
+		Double longitude = 127.123;
+
+		when(brandRepository.findById(brandId)).thenReturn(Optional.empty());
+
+		// when
+		GlobalException exception = assertThrows(GlobalException.class, () -> {
+			brandService.getNearestStoreCoordination(latitude, longitude, brandId);
+		});
+
+		// then
+		assertEquals(4000, exception.getResultCode().getCode());
+	}
+
+	@Test
+	@DisplayName("매장 위경도가 존재하지 않을 경우 에러가 발생한다.")
+	void getNearestBrandStoreIsNull() {
+		// given
+		Long brandId = 1L;
+		Double latitude = 37.123;
+		Double longitude = 127.123;
+
+		Brand mockBrand = mock(Brand.class);
+		Store mockStore = mock(Store.class);
+
+		when(brandRepository.findById(brandId)).thenReturn(Optional.ofNullable(mockBrand));
+		when(storeRepository.findNearestByBrandId(brandId, latitude, longitude)).thenReturn(mockStore);
+		when(mockStore.getLocation()).thenReturn(null);
+
+		// when
+		GlobalException exception = assertThrows(GlobalException.class, () -> {
+			brandService.getNearestStoreCoordination(latitude, longitude, brandId);
+		});
+
+		// then
+		assertEquals(4002, exception.getResultCode().getCode());
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #159 

## 📝작업 내용
- brandId를 기준으로 가장 가까운 제휴처 매장의 위경도를 반환하는 API를 구현하였습니다.
- brandId가 유효하지 않거나, 매장의 Location 정보가 비어있는 경우 예외가 발생합니다.
- isOnline인 경우 항상 매장이 존재하지 않기 때문에, 이를 먼저 구분할 수 있도록 상세보기의 DTO에 isOnline 필드를 추가하였습니다.
- 관련 테스트 코드를 작성하였습니다.


## 📷스크린샷 (선택)

<img width="324" height="173" alt="image" src="https://github.com/user-attachments/assets/c643029a-4ce4-41ec-8b66-92cae4f6fa91" />

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 브랜드별로 지정한 위치 기준 가장 가까운 오프라인 매장 좌표를 조회하는 API가 추가되었습니다.
  * 브랜드 상세 정보에 브랜드의 온라인 여부(isOnline) 표시가 추가되었습니다.

* **버그 수정**
  * 오프라인 매장이 없는 경우 관련 오류 메시지가 제공됩니다.

* **테스트**
  * 가장 가까운 매장 좌표 조회 기능 및 예외 상황에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->