### PR TITLE
[feat] 매장 클러스터링 캐싱 로직 추가

### DIFF
--- a/src/main/java/com/ureca/uble/domain/store/dto/response/EmptyStoreRes.java
+++ b/src/main/java/com/ureca/uble/domain/store/dto/response/EmptyStoreRes.java
@@ -1,0 +1,10 @@
+package com.ureca.uble.domain.store.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+import java.io.Serializable;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class EmptyStoreRes implements Serializable {
+    private final boolean empty = true;
+}

--- a/src/main/java/com/ureca/uble/domain/store/dto/response/GetStoreRes.java
+++ b/src/main/java/com/ureca/uble/domain/store/dto/response/GetStoreRes.java
@@ -2,13 +2,16 @@ package com.ureca.uble.domain.store.dto.response;
 
 import com.ureca.uble.entity.Store;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
+
+import java.io.Serializable;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Schema(description = "매장 정보 반환 DTO")
-public class GetStoreRes {
+public class GetStoreRes implements Serializable {
     @Schema(description = "매장 id", example = "1")
     private Long storeId;
 

--- a/src/main/java/com/ureca/uble/domain/store/dto/response/StoreCacheResult.java
+++ b/src/main/java/com/ureca/uble/domain/store/dto/response/StoreCacheResult.java
@@ -1,0 +1,23 @@
+package com.ureca.uble.domain.store.dto.response;
+
+import com.google.common.geometry.S2CellId;
+
+import java.util.List;
+
+public class StoreCacheResult {
+    private final List<GetStoreRes> hitStores;
+    private final List<S2CellId> missCells;
+
+    public StoreCacheResult(List<GetStoreRes> hitStores, List<S2CellId> missedCells) {
+        this.hitStores = hitStores;
+        this.missCells = missedCells;
+    }
+
+    public List<GetStoreRes> getHitStores() {
+        return hitStores;
+    }
+
+    public List<S2CellId> getMissCells() {
+        return missCells;
+    }
+}

--- a/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/ureca/uble/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -42,7 +42,7 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
                 .innerJoin(store.brand, brand).fetchJoin()
                 .innerJoin(brand.category, category).fetchJoin()
                 .where(
-                        cellsContain(cellIds), // 동적으로 OR 조건 생성
+                        cellsContain(cellIds),
                         categoryIdEq(categoryId),
                         brandIdEq(brandId),
                         seasonEq(season),

--- a/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
+++ b/src/main/java/com/ureca/uble/domain/store/service/StoreService.java
@@ -20,11 +20,13 @@ import com.ureca.uble.entity.enums.*;
 import com.ureca.uble.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static com.ureca.uble.domain.common.exception.CommonErrorCode.ELASTIC_INTERNAL_ERROR;
 import static com.ureca.uble.domain.store.exception.StoreErrorCode.OUT_OF_RANGE_INPUT;
@@ -43,6 +45,7 @@ public class StoreService {
     private final StoreClickLogDocumentRepository storeClickLogDocumentRepository;
     private final LocationCoordinationDocumentRepository locationCoordinationDocumentRepository;
     private final CustomElasticRepository customElasticRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     private static final int MAP_MAX_ZOOM = 21;
     private static final int FULL_RETURN_ZOOM_THRESHOLD = 16;
@@ -70,7 +73,7 @@ public class StoreService {
             return new GetStoreListRes(zoomLevel, fullList);
         }
 
-        // 낮은 줌 레벨: S2 셀 기반 클러스터링으로 대표 매장만 반환 (지도를 넓게 볼 때)
+        // 낮은 줌 레벨
         return createClusteredStoreListResponseFromDB(zoomLevel, swLat, swLng, neLat, neLng,
                 categoryId, brandId, season, type);
     }
@@ -81,34 +84,150 @@ public class StoreService {
     private GetStoreListRes createClusteredStoreListResponseFromDB(int zoomLevel, double swLat, double swLng,
                                                                    double neLat, double neLng, Long categoryId,
                                                                    Long brandId, Season season, BenefitType type) {
-        // 줌 레벨에 따른 S2 셀 크기 결정
+        // 커버링 셀 계산
         int cellLevel = getCellLevelFromZoom(zoomLevel);
-        // 지도 화면의 남서쪽(sw)과 북동쪽(ne) 모서리 좌표를 이용해 사각형 영역 객체를 생성
-        S2LatLngRect rect = S2LatLngRect.fromPointPair(S2LatLng.fromDegrees(swLat, swLng), S2LatLng.fromDegrees(neLat, neLng));
-        S2RegionCoverer coverer = S2RegionCoverer.builder().setMinLevel(cellLevel).setMaxLevel(cellLevel).build();
-        ArrayList<S2CellId> coveringCells = new ArrayList<>();
-        coverer.getCovering(rect, coveringCells);
+        List<S2CellId> coveringCells = getCoveringCells(swLat, swLng, neLat, neLng, cellLevel);
+        if (coveringCells.isEmpty()) {
+            return new GetStoreListRes(zoomLevel, List.of());
+        }
 
-        // 셀 목록에 포함되는 모든 매장 정보를 한 번에 조회
-        List<Store> storesInCells = storeRepository.findStoresInCellRanges(coveringCells, categoryId, brandId, season, type);
+        // 캐시 조회 및 분류
+        List<String> cacheKeys = buildCacheKeys(coveringCells, categoryId, brandId, season, type);
+        CacheScanResult scan = scanCache(coveringCells, cacheKeys);
 
-        // 애플리케이션에서 대표 매장 그룹화
-        Map<Long, Store> representativeStores = new HashMap<>();
-        for (Store store : storesInCells) {
-            S2LatLng latLng = S2LatLng.fromDegrees(store.getLocation().getY(), store.getLocation().getX());
-            S2CellId parentCellId = S2CellId.fromLatLng(latLng).parent(cellLevel);
+        List<GetStoreRes> finalStoreList = new ArrayList<>(scan.hitStores);
 
-            Store existingRepresentative = representativeStores.get(parentCellId.id());
-            if (existingRepresentative == null || store.getVisitCount() > existingRepresentative.getVisitCount()) {
-                representativeStores.put(parentCellId.id(), store);
+        // 캐시 미스 셀에 대해서만 DB 조회 및 대표 매장 선출
+        if (!scan.missedCells.isEmpty()) {
+            Map<Long, Store> representatives = findRepresentativesByCells(scan.missedCells, cellLevel, categoryId, brandId, season, type);
+
+            // 대표 매장 응답 변환 및 캐시 저장
+            if (!representatives.isEmpty()) {
+                Map<String, GetStoreRes> toCache = new HashMap<>();
+                for (Map.Entry<Long, Store> e : representatives.entrySet()) {
+                    Store store = e.getValue();
+                    String key = buildCacheKey(new S2CellId(e.getKey()), categoryId, brandId, season, type);
+                    toCache.put(key, GetStoreRes.from(store));
+                    finalStoreList.add(GetStoreRes.from(store));
+                }
+                cacheMultiSetWithTtl(toCache);
+            }
+
+            // 빈 셀 마커 캐시 저장
+            Map<String, EmptyStoreRes> emptyMarkers = new HashMap<>();
+            for (S2CellId missed : scan.missedCells) {
+                if (!representatives.containsKey(missed.id())) {
+                    String key = buildCacheKey(missed, categoryId, brandId, season, type);
+                    emptyMarkers.put(key, new EmptyStoreRes());
+                }
+            }
+            if (!emptyMarkers.isEmpty()) {
+                cacheMultiSetEmptyWithTtl(emptyMarkers);
             }
         }
 
-        List<GetStoreRes> responseList = representativeStores.values().stream()
-                .map(GetStoreRes::from)
-                .collect(Collectors.toList());
+        return new GetStoreListRes(zoomLevel, finalStoreList);
+    }
 
-        return new GetStoreListRes(zoomLevel, responseList);
+    // 줌 레벨에 맞는 s2 셀로 영역 생성
+    private List<S2CellId> getCoveringCells(double swLat, double swLng, double neLat, double neLng, int cellLevel) {
+        S2LatLngRect rect = S2LatLngRect.fromPointPair(
+                S2LatLng.fromDegrees(swLat, swLng),
+                S2LatLng.fromDegrees(neLat, neLng)
+        );
+        S2RegionCoverer coverer = S2RegionCoverer.builder()
+                .setMinLevel(cellLevel)
+                .setMaxLevel(cellLevel)
+                .build();
+
+        ArrayList<S2CellId> cells = new ArrayList<>();
+        coverer.getCovering(rect, cells);
+        return cells;
+    }
+
+    //각 셀 ID에 Redis 캐시 키 생성
+    private List<String> buildCacheKeys(List<S2CellId> cells, Long categoryId, Long brandId, Season season, BenefitType type) {
+        return cells.stream()
+                .map(cell -> buildCacheKey(cell, categoryId, brandId, season, type))
+                .toList();
+    }
+
+    private static final class CacheScanResult {
+        final List<GetStoreRes> hitStores;
+        final List<S2CellId> missedCells;
+
+        CacheScanResult(List<GetStoreRes> hitStores, List<S2CellId> missedCells) {
+            this.hitStores = hitStores;
+            this.missedCells = missedCells;
+        }
+    }
+
+    //Hit/Miss된 셀 목록으로 분류
+    private CacheScanResult scanCache(List<S2CellId> coveringCells, List<String> cacheKeys) {
+        List<Object> cached = redisTemplate.opsForValue().multiGet(cacheKeys);
+
+        List<GetStoreRes> hits = new ArrayList<>();
+        List<S2CellId> misses = new ArrayList<>();
+
+        List<Object> safeCached = Objects.requireNonNullElseGet(cached, List::of);
+        for (int i = 0; i < safeCached.size(); i++) {
+            Object obj = safeCached.get(i);
+            if (obj instanceof GetStoreRes res) {
+                hits.add(res);
+                log.info("Map-Cache Hit for key: {}", cacheKeys.get(i));
+            } else if (obj instanceof EmptyStoreRes) {
+                log.info("Map-Cache Empty hit for cellId: {}", coveringCells.get(i).toToken());
+            } else {
+                misses.add(coveringCells.get(i));
+                log.info("Map-Cache Miss for cellId: {}", coveringCells.get(i).toToken());
+            }
+        }
+        return new CacheScanResult(hits, misses);
+    }
+
+    //대표 매장 선정
+    private Map<Long, Store> findRepresentativesByCells(
+            List<S2CellId> missedCells, int cellLevel,
+            Long categoryId, Long brandId, Season season, BenefitType type
+    ) {
+        List<Store> stores = storeRepository.findStoresInCellRanges(missedCells, categoryId, brandId, season, type);
+
+        Map<Long, Store> representatives = new HashMap<>();
+        for (Store store : stores) {
+            S2LatLng latLng = S2LatLng.fromDegrees(store.getLocation().getY(), store.getLocation().getX());
+            S2CellId parent = S2CellId.fromLatLng(latLng).parent(cellLevel);
+
+            Store current = representatives.get(parent.id());
+            if (current == null || store.getVisitCount() > current.getVisitCount()) {
+                representatives.put(parent.id(), store);
+            }
+        }
+        return representatives;
+    }
+
+    private void cacheMultiSetWithTtl(Map<String, GetStoreRes> data) {
+        redisTemplate.opsForValue().multiSet(data);
+        redisTemplate.executePipelined((RedisCallback<Object>) conn -> {
+            for (String key : data.keySet()) {
+                conn.keyCommands().expire(key.getBytes(), Duration.ofMinutes(10).getSeconds());
+            }
+            return null;
+        });
+    }
+
+    private void cacheMultiSetEmptyWithTtl(Map<String, EmptyStoreRes> empties) {
+        redisTemplate.opsForValue().multiSet(empties);
+        redisTemplate.executePipelined((RedisCallback<Object>) conn -> {
+            for (String key : empties.keySet()) {
+                conn.keyCommands().expire(key.getBytes(), Duration.ofMinutes(10).getSeconds());
+            }
+            return null;
+        });
+    }
+
+    private String buildCacheKey(S2CellId cellId, Long categoryId, Long brandId, Season season, BenefitType type) {
+        return String.format("stores:cell:%d:cat:%s:brand:%s:season:%s:type:%s",
+                cellId.id(), categoryId, brandId, season, type);
     }
 
     private int getCellLevelFromZoom(int zoomLevel) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #151 

## 📝작업 내용

- 매장 클러스터링 캐싱 로직 추가 (줌 레벨 16 미만 12이상 S2 셀 기반)
- s2_cell_id 컬럼 기반 클러스터 대표 매장 선별 적용

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 지도 클러스터링 결과에 대한 Redis 캐싱이 도입되어, 지도 영역 내 매장 조회 시 응답 속도가 개선되고 데이터베이스 부하가 감소합니다.
  * 빈 매장 응답을 위한 새로운 응답 객체가 추가되었습니다.

* **버그 수정**
  * 없음

* **리팩터링**
  * 매장 클러스터링 로직이 캐시 우선 방식으로 구조가 개선되었습니다.
  * 일부 클래스에 직렬화 및 생성자 관련 어노테이션이 추가되었습니다.

* **테스트**
  * Redis 캐시 동작과 S2 셀 기반 클러스터링을 반영하도록 테스트 코드가 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->